### PR TITLE
Ensure bidRequest health check uses rewritten URI

### DIFF
--- a/deploy/k8s/configs/gateway-config.yaml
+++ b/deploy/k8s/configs/gateway-config.yaml
@@ -115,7 +115,7 @@ data:
           rewrite ^/bidRequest/nurl/?$ /nurl break;
           rewrite ^/bidRequest/burl/?$ /burl break;
           rewrite ^/bidRequest/health/?$ /health break;
-          proxy_pass http://spp_adapter;
+          proxy_pass http://spp_adapter$uri;
         }
 
         location /spp-adapter/ {


### PR DESCRIPTION
## Summary
- update the bidRequest location in the gateway configuration to forward the rewritten URI to the spp adapter

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc03d6e1a88328bbfc70872791c0ae