### PR TITLE
Improve DSP router latency tuning

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -16,10 +16,15 @@ import (
 	dspRouterGrpc "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/dspRouter"
 	dspRouterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/dspRouter/web"
 
+	"go.uber.org/automaxprocs/maxprocs"
 	"google.golang.org/grpc"
 )
 
 func main() {
+	if _, err := maxprocs.Set(); err != nil {
+		log.Printf("automaxprocs setup failed: %v", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -80,6 +85,8 @@ func main() {
 			cfg.DSPEndpoints_v_2_5,
 			redisClient,
 			cfg.BidResponsesTimeout,
+			cfg.MaxParallelRequests,
+			cfg.Debug,
 		),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/ggicci/httpin v0.17.0
-	github.com/go-chi/chi v1.5.5
-	github.com/go-chi/chi/v5 v5.2.2
-	github.com/jmoiron/sqlx v1.4.0
-	github.com/unrolled/render v1.7.0
+        github.com/ggicci/httpin v0.17.0
+        github.com/go-chi/chi v1.5.5
+        github.com/go-chi/chi/v5 v5.2.2
+        github.com/jmoiron/sqlx v1.4.0
+        github.com/unrolled/render v1.7.0
+        go.uber.org/automaxprocs v0.0.0
 )
 
 require (
@@ -57,6 +58,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
 )
+
+replace go.uber.org/automaxprocs => ./internal/automaxprocs
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.3

--- a/internal/automaxprocs/go.mod
+++ b/internal/automaxprocs/go.mod
@@ -1,0 +1,3 @@
+module go.uber.org/automaxprocs
+
+go 1.24.0

--- a/internal/automaxprocs/maxprocs/maxprocs.go
+++ b/internal/automaxprocs/maxprocs/maxprocs.go
@@ -1,0 +1,112 @@
+package maxprocs
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Set adjusts GOMAXPROCS to match the CPU quota detected in the current cgroup.
+// It returns a function that restores the previous value and an error if the
+// detection logic failed in an unexpected way.
+func Set() (func(), error) {
+	previous := runtime.GOMAXPROCS(0)
+
+	maxProcs, err := recommendedProcs()
+	if err != nil {
+		return func() { runtime.GOMAXPROCS(previous) }, err
+	}
+
+	if maxProcs > 0 && maxProcs != previous {
+		runtime.GOMAXPROCS(maxProcs)
+	}
+
+	return func() { runtime.GOMAXPROCS(previous) }, nil
+}
+
+func recommendedProcs() (int, error) {
+	if env := os.Getenv("GOMAXPROCS"); env != "" {
+		if value, err := strconv.Atoi(env); err == nil && value > 0 {
+			return value, nil
+		}
+	}
+
+	if quota, period, ok := readCgroupV2(); ok {
+		return quotaToProcs(quota, period), nil
+	}
+
+	if quota, period, ok := readCgroupV1(); ok {
+		return quotaToProcs(quota, period), nil
+	}
+
+	return 0, nil
+}
+
+func quotaToProcs(quota, period int64) int {
+	if quota <= 0 || period <= 0 {
+		return 0
+	}
+
+	procs := int((quota + period - 1) / period)
+	if procs < 1 {
+		procs = 1
+	}
+	return procs
+}
+
+func readCgroupV2() (quota, period int64, ok bool) {
+	data, err := os.ReadFile("/sys/fs/cgroup/cpu.max")
+	if err != nil {
+		return 0, 0, false
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0, 0, false
+	}
+
+	if fields[0] == "max" {
+		return 0, 0, true
+	}
+
+	quota, err = strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	period, err = strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return quota, period, true
+}
+
+func readCgroupV1() (quota, period int64, ok bool) {
+	quotaBytes, err := os.ReadFile("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+	if err != nil {
+		return 0, 0, false
+	}
+
+	periodBytes, err := os.ReadFile("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+	if err != nil {
+		return 0, 0, false
+	}
+
+	quota, err = strconv.ParseInt(strings.TrimSpace(string(quotaBytes)), 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	period, err = strconv.ParseInt(strings.TrimSpace(string(periodBytes)), 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	if quota == -1 {
+		return 0, 0, true
+	}
+
+	return quota, period, true
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,9 @@ type RouterConfig struct {
 
 	BidResponsesTimeout time.Duration `yaml:"BID_RESPONSES_TIMEOUT" env:"BID_RESPONSES_TIMEOUT"`
 
+	MaxParallelRequests int  `yaml:"MAX_PARALLEL_REQUESTS" env:"MAX_PARALLEL_REQUESTS" env-default:"64"`
+	Debug               bool `yaml:"DEBUG" env:"DEBUG" env-default:"false"`
+
 	RedisConfig
 }
 


### PR DESCRIPTION
## Summary
- add configurable HTTP client pooling, concurrency limits, and conditional logging to the DSP router server
- stream JSON decoding, handle 204 responses gracefully, and capture metadata without defer delays
- expose router debug/max-parallel config flags, wire automaxprocs, and vendor a lightweight implementation for offline builds

## Testing
- go test ./... *(fails: hangs indefinitely, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb561990c8328912c13af43f98b2d