### PR TITLE
Tune swarm routing for low latency

### DIFF
--- a/deploy/docker-swarm/docker-stack.yaml
+++ b/deploy/docker-swarm/docker-stack.yaml
@@ -21,36 +21,55 @@ services:
   mock-dsp-1:
     image: localhost:5000/rtb/mock-dsp-1:local
     hostname: mock-dsp-1
+    ports:
+      - target: 8090
+        published: 8090
+        mode: host
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+      endpoint_mode: dnsrr
     env_file:
       - env/mock-dsp-1.env
 
   mock-dsp-2:
     image: localhost:5000/rtb/mock-dsp-2:local
     hostname: mock-dsp-2
+    ports:
+      - target: 8091
+        published: 8091
+        mode: host
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+      endpoint_mode: dnsrr
     env_file:
       - env/mock-dsp-2.env
 
   mock-dsp-3:
     image: localhost:5000/rtb/mock-dsp-3:local
     hostname: mock-dsp-3
+    ports:
+      - target: 8092
+        published: 8092
+        mode: host
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+      endpoint_mode: dnsrr
     env_file:
       - env/mock-dsp-3.env
 
   redis:
     image: redis:7-alpine
     hostname: redis
+    ports:
+      - target: 6379
+        published: 6379
+        mode: host
     env_file:
       - env/redis.env
     command: ["sh", "-c", "redis-server --requirepass \"$${REDIS_PASSWORD}\""]
@@ -68,10 +87,15 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      endpoint_mode: dnsrr
 
   kafka:
     image: apache/kafka:3.7.0
     hostname: kafka
+    ports:
+      - target: 9092
+        published: 9092
+        mode: host
     env_file:
       - env/kafka.env
     volumes:
@@ -82,6 +106,7 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      endpoint_mode: dnsrr
       resources:
         limits:
           memory: 1G
@@ -98,6 +123,10 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.rtb_latency == true
     depends_on:
       - redis
 
@@ -116,6 +145,10 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.rtb_latency == true
     depends_on:
       - redis
 
@@ -129,6 +162,10 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.rtb_latency == true
     depends_on:
       - redis
       - bid-engine
@@ -144,6 +181,9 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      placement:
+        constraints:
+          - node.labels.rtb_latency == true
     depends_on:
       - redis
       - orchestrator
@@ -178,15 +218,27 @@ services:
   nginx-gateway:
     image: nginx:alpine
     ports:
-      - "80:80"
-      - "443:443"
-      - "9092:9092"
-      - "6379:6379"
-      - "8083:8083"
-      - "8084:8084"
-      - "8085:8085"
-      - "8087:8087"
-      - "8088:8088"
+      - target: 80
+        published: 80
+        mode: host
+      - target: 443
+        published: 443
+        mode: host
+      - target: 8083
+        published: 8083
+        mode: host
+      - target: 8084
+        published: 8084
+        mode: host
+      - target: 8085
+        published: 8085
+        mode: host
+      - target: 8087
+        published: 8087
+        mode: host
+      - target: 8088
+        published: 8088
+        mode: host
     volumes:
       - nginx_logs:/var/log/nginx
     configs:
@@ -203,6 +255,9 @@ services:
         condition: on-failure
         delay: 10s
         max_attempts: 5
+      placement:
+        constraints:
+          - node.labels.rtb_latency == true
     depends_on:
       - redis
       - kafka

--- a/deploy/docker-swarm/first-deploy.sh
+++ b/deploy/docker-swarm/first-deploy.sh
@@ -36,6 +36,37 @@ if [ "${missing}" -ne 0 ]; then
     exit 1
 fi
 
+LATENCY_NODE_INPUT="${1:-${LATENCY_NODE:-}}"
+
+if [ -z "${LATENCY_NODE_INPUT}" ]; then
+    SELF_NODE_ID="$(docker info --format '{{.Swarm.NodeID}}' 2>/dev/null || true)"
+    if [ -n "${SELF_NODE_ID}" ] && docker node inspect "${SELF_NODE_ID}" >/dev/null 2>&1; then
+        LATENCY_NODE="${SELF_NODE_ID}"
+    else
+        LATENCY_NODE="$(docker node ls --filter role=manager --format '{{.ID}}' | head -n1)"
+    fi
+else
+    if docker node inspect "${LATENCY_NODE_INPUT}" >/dev/null 2>&1; then
+        LATENCY_NODE="${LATENCY_NODE_INPUT}"
+    else
+        LATENCY_NODE="$(docker node ls --format '{{.ID}} {{.Hostname}}' | awk -v target="${LATENCY_NODE_INPUT}" '$2 == target {print $1; exit}')"
+    fi
+fi
+
+if [ -z "${LATENCY_NODE}" ]; then
+    echo "❌ Не удалось определить ноду для метки rtb_latency. Укажите идентификатор или имя ноды в качестве аргумента или переменной LATENCY_NODE."
+    exit 1
+fi
+
+LATENCY_NODE_NAME="$(docker node inspect -f '{{.Description.Hostname}}' "${LATENCY_NODE}" 2>/dev/null || echo "${LATENCY_NODE}")"
+CURRENT_LABEL="$(docker node inspect -f '{{ index .Spec.Labels "rtb_latency" }}' "${LATENCY_NODE}" 2>/dev/null || true)"
+if [ "${CURRENT_LABEL}" != "true" ]; then
+    echo "🏷️  Добавляем метку rtb_latency=true на ноду ${LATENCY_NODE_NAME} (${LATENCY_NODE})"
+    docker node update --label-add rtb_latency=true "${LATENCY_NODE}"
+else
+    echo "🏷️  Метка rtb_latency=true уже установлена на ноде ${LATENCY_NODE_NAME} (${LATENCY_NODE})"
+fi
+
 echo "📦 Deploying RTB Stack..."
 docker stack deploy -c "${STACK_FILE}" "${STACK_NAME}"
 

--- a/deploy/docker-swarm/nginx.conf
+++ b/deploy/docker-swarm/nginx.conf
@@ -1,31 +1,18 @@
-events {
-    worker_connections 1024;
-}
+worker_processes auto;
 
-stream {
-    upstream redis_backend {
-        server rtb_redis:6379;
-    }
-    
-    server {
-        listen 6379;
-        proxy_pass redis_backend;
-        proxy_timeout 3s;
-        proxy_responses 1;
-    }
-    
-    upstream kafka_backend {
-        server rtb_kafka:9092;
-    }
-    
-    server {
-        listen 9092;
-        proxy_pass kafka_backend;
-        proxy_timeout 3s;
-    }
+events {
+    worker_connections 4096;
+    multi_accept on;
 }
 
 http {
+    resolver 127.0.0.11 ipv6=off valid=5s;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    keepalive_requests 1000;
+
     log_format timing '[$time_local] "$request" '
                      'connect_time=$upstream_connect_time '
                      'header_time=$upstream_header_time '
@@ -35,33 +22,48 @@ http {
     access_log /var/log/nginx/timing.log timing;
 
     upstream spp_adapter {
-        server rtb_spp-adapter:8086;
+        zone spp 64k;
+        server tasks.rtb_spp-adapter:8086 max_fails=0 resolve;
+        keepalive 256;
     }
-    
+
     upstream bid_engine_grpc {
-        server rtb_bid-engine:8084;
+        zone bid_engine 64k;
+        server tasks.rtb_bid-engine:8084 max_fails=0 resolve;
+        keepalive 256;
     }
-    
+
     upstream orchestrator_grpc {
-        server rtb_orchestrator:8085;
+        zone orchestrator 64k;
+        server tasks.rtb_orchestrator:8085 max_fails=0 resolve;
+        keepalive 256;
     }
-    
+
     upstream router_grpc {
-        server rtb_router:8083;
+        zone router 64k;
+        server tasks.rtb_router:8083 max_fails=0 resolve;
+        keepalive 256;
     }
 
     upstream kafka_loader {
-        server rtb_kafka-loader:8087;
+        zone kafka_loader 64k;
+        server tasks.rtb_kafka-loader:8087 max_fails=0 resolve;
+        keepalive 256;
     }
 
     upstream clickhouse_loader {
-        server rtb_clickhouse-loader:8088;
+        zone clickhouse_loader 64k;
+        server tasks.rtb_clickhouse-loader:8088 max_fails=0 resolve;
+        keepalive 256;
     }
+
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
 
     server {
         listen 80;
         server_name twinbidexchange.com www.twinbidexchange.com;
-        
+
         location / {
             return 301 https://$server_name$request_uri;
         }
@@ -94,25 +96,37 @@ http {
             proxy_read_timeout 10s;
         }
     }
-    
+
     server {
         listen 8084 http2;
         location / {
             grpc_pass grpc://bid_engine_grpc;
+            grpc_socket_keepalive on;
+            grpc_connect_timeout 250ms;
+            grpc_read_timeout 5s;
+            grpc_send_timeout 5s;
         }
     }
-    
+
     server {
         listen 8085 http2;
         location / {
             grpc_pass grpc://orchestrator_grpc;
+            grpc_socket_keepalive on;
+            grpc_connect_timeout 250ms;
+            grpc_read_timeout 5s;
+            grpc_send_timeout 5s;
         }
     }
-    
+
     server {
         listen 8083 http2;
         location / {
             grpc_pass grpc://router_grpc;
+            grpc_socket_keepalive on;
+            grpc_connect_timeout 250ms;
+            grpc_read_timeout 5s;
+            grpc_send_timeout 5s;
         }
     }
 
@@ -120,6 +134,9 @@ http {
         listen 8088;
         location / {
             proxy_pass http://clickhouse_loader;
+            proxy_connect_timeout 1s;
+            proxy_send_timeout 5s;
+            proxy_read_timeout 5s;
         }
     }
 
@@ -127,6 +144,9 @@ http {
         listen 8087;
         location / {
             proxy_pass http://kafka_loader;
+            proxy_connect_timeout 1s;
+            proxy_send_timeout 5s;
+            proxy_read_timeout 5s;
         }
     }
 }


### PR DESCRIPTION
## Summary
- publish ingress ports in host mode and enable dnsrr endpoints to avoid extra VIP hops in Swarm
- expose mock DSP, Redis and Kafka directly while keeping latency-critical services on the same labeled node
- rework the nginx gateway to talk to tasks.* backends with connection reuse and tighter timeouts, removing the Redis/Kafka stream proxy layer
- ensure the first-deploy helper script automatically labels the latency node before deploying the stack

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfe0d0f8b883288acd925d100d4111