### PR TITLE
Process only full batches in Kafka/ClickHouse loaders

### DIFF
--- a/internal/services/clickhouse-loader/clicks.go
+++ b/internal/services/clickhouse-loader/clicks.go
@@ -55,7 +55,7 @@ func ProcessKafkaMessagesClicks(
 		messages = append(messages, msg)
 	}
 
-	if len(records) == 0 {
+	if len(records) < batchSize {
 		time.Sleep(1 * time.Second)
 		return nil
 	}

--- a/internal/services/clickhouse-loader/impressions.go
+++ b/internal/services/clickhouse-loader/impressions.go
@@ -55,7 +55,7 @@ func ProcessKafkaMessagesImpressions(
 		messages = append(messages, msg)
 	}
 
-	if len(records) == 0 {
+	if len(records) < batchSize {
 		time.Sleep(1 * time.Second)
 		return nil
 	}

--- a/internal/services/kafka-loader/clicks.go
+++ b/internal/services/kafka-loader/clicks.go
@@ -26,7 +26,7 @@ func ProcessBatchClicks(ctx context.Context, redisClient *redis.Client, kafkaWri
 		return fmt.Errorf("failed to get UUIDs from Redis set %q: %v", setName, err)
 	}
 
-	if len(uuids) == 0 {
+	if len(uuids) < int(batchSize) {
 		return nil
 	}
 

--- a/internal/services/kafka-loader/impressions.go
+++ b/internal/services/kafka-loader/impressions.go
@@ -26,7 +26,7 @@ func ProcessBatchImpressions(ctx context.Context, redisClient *redis.Client, kaf
 		return fmt.Errorf("failed to get UUIDs from Redis set %q: %v", setName, err)
 	}
 
-	if len(uuids) == 0 {
+	if len(uuids) < int(batchSize) {
 		return nil
 	}
 


### PR DESCRIPTION
### Motivation

- Prevent partial or underfilled batches from being sent to Kafka/ClickHouse and avoid committing offsets or deleting Redis entries when batch size target isn't met.

### Description

- Changed Redis/Kafka loader checks from `len(uuids) == 0` to `len(uuids) < int(batchSize)` in `internal/services/kafka-loader/clicks.go` and `internal/services/kafka-loader/impressions.go` to skip processing unless a full batch is retrieved.
- Changed ClickHouse loader checks from `len(records) == 0` to `len(records) < batchSize` in `internal/services/clickhouse-loader/clicks.go` and `internal/services/clickhouse-loader/impressions.go` to avoid inserting partial batches and committing offsets.
- Preserves existing behavior of sleeping for `1s` and returning when batch is not full to throttle polling.

### Testing

- Ran `go build` and `go test ./...` locally to validate compilation and unit tests, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a781ac438832884dea189bbd448c1)