### PR TITLE
Add Redis write error monitor, SSP work-status control, loader callbacks and helpers

### DIFF
--- a/cmd/adm-adapter/main.go
+++ b/cmd/adm-adapter/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/config"
 	httpServer "gitlab.com/twinbid-exchange/RTB-exchange/internal/http"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	redis_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/redis"
 	sppAdapterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/sspAdapter/web"
 )
@@ -51,6 +52,11 @@ func main() {
 	}
 	log.Println("✅ Connected to Clicks Redis shards")
 
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("adm-adapter", func(count uint64) {
+		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
+	})
+	redisWriteErrorMonitor.Start()
+
 	router := httpServer.InitHttpRouter(chi.NewRouter())
 	sppAdapterWeb.InitHttpsRoutes(
 		ctx,
@@ -61,6 +67,7 @@ func main() {
 		cfg.RedisSetClicks,
 		cfg.AdmTimeout,
 		cfg.NurlTimeout,
+		redisWriteErrorMonitor,
 	)
 	log.Println("HTTP routes initialized")
 

--- a/cmd/bid-engine/main.go
+++ b/cmd/bid-engine/main.go
@@ -14,6 +14,7 @@ import (
 	bidEngineGrpc "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/bidEngine"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	httpServer "gitlab.com/twinbid-exchange/RTB-exchange/internal/http"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	bidEngine "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/bidEngine/service"
 	bidEngineWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/bidEngine/web"
 	redis_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/redis"
@@ -78,6 +79,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("bid-engine", func(count uint64) {
+		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
+	})
+	redisWriteErrorMonitor.Start()
+
 	s := grpc.NewServer()
 	bidEngineGrpc.RegisterBidEngineServiceServer(
 		s,
@@ -91,6 +97,7 @@ func main() {
 			cfg.SspGeoDspPercentsMainstreamFilePath,
 			&sspGeoDspMapMainstream,
 			cfg.AdmDomain,
+			redisWriteErrorMonitor,
 		),
 	)
 

--- a/cmd/clickhouse-loader/main.go
+++ b/cmd/clickhouse-loader/main.go
@@ -124,6 +124,10 @@ func main() {
 	}
 
 	var loaderWG sync.WaitGroup
+	handleStreamError := func(err error) {
+		log.Printf("❌ ClickHouse Loader stream error, stopping batch processing: %v", err)
+		loaderControl.Stop()
+	}
 	emptyPause := time.Duration(cfg.EmptyLoopPauseMS) * time.Millisecond
 	if emptyPause <= 0 {
 		emptyPause = 200 * time.Millisecond
@@ -147,8 +151,7 @@ func main() {
 				cfg.Clickhouse.BatchTimeoutMS,
 			)
 			if err != nil {
-				log.Printf("❌ ClickHouse Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 			if inserted == 0 {
@@ -181,8 +184,7 @@ func main() {
 				cfg.Clickhouse.BatchTimeoutMS,
 			)
 			if err != nil {
-				log.Printf("❌ ClickHouse Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 		}
@@ -208,8 +210,7 @@ func main() {
 				cfg.Clickhouse.BatchTimeoutMS,
 			)
 			if err != nil {
-				log.Printf("❌ ClickHouse Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 		}

--- a/cmd/kafka-loader/main.go
+++ b/cmd/kafka-loader/main.go
@@ -106,6 +106,8 @@ func main() {
 	}
 	batchRatioManager := services.NewBatchRatioManager(impressionsPercent, clicksPercent, cfg.BatchRatioConfig.TickerEnabled)
 	loaderControl := services.NewLoaderControl(false)
+	stopSspOnce := services.NewResettableOnce()
+	loaderControl.AddOnStart(stopSspOnce.Reset)
 
 	batchRatioManager.StartClickHouseTicker(ctx, connProd, cfg.BatchRatioConfig)
 	batchRatioManager.StartHTTPServer(ctx, cfg.BatchRatioConfig, loaderControl)
@@ -119,6 +121,13 @@ func main() {
 	}
 
 	var loaderWG sync.WaitGroup
+	handleStreamError := func(err error) {
+		log.Printf("❌ Kafka Loader stream error, stopping batch processing and SSP adapter ORTB streams: %v", err)
+		loaderControl.Stop()
+		stopSspOnce.Do(func() {
+			services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
+		})
+	}
 	emptyPause := time.Duration(cfg.EmptyLoopPauseMS) * time.Millisecond
 	if emptyPause <= 0 {
 		emptyPause = 200 * time.Millisecond
@@ -147,8 +156,7 @@ func main() {
 				cfg.RedisSetOrtb,
 			)
 			if err != nil {
-				log.Printf("❌ Kafka Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 			if processed == 0 {
@@ -179,8 +187,7 @@ func main() {
 				cfg.RedisSetImpressions,
 			)
 			if err != nil {
-				log.Printf("❌ Kafka Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 		}
@@ -204,8 +211,7 @@ func main() {
 				cfg.RedisSetClicks,
 			)
 			if err != nil {
-				log.Printf("❌ Kafka Loader stream error, stopping batch processing: %v", err)
-				loaderControl.Stop()
+				handleStreamError(err)
 				continue
 			}
 		}

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -17,6 +17,7 @@ import (
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	httpServer "gitlab.com/twinbid-exchange/RTB-exchange/internal/http"
 	maxproc "gitlab.com/twinbid-exchange/RTB-exchange/internal/mp"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	dspRouterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/dspRouter/web"
 	redis_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/redis"
 
@@ -146,6 +147,11 @@ func main() {
 		log.Fatalf("Failed to InitCidSspDspMap: %v", err)
 	}
 
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("router", func(count uint64) {
+		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
+	})
+	redisWriteErrorMonitor.Start()
+
 	s := grpc.NewServer()
 	routerServer := dspRouterWeb.NewServer(
 		ruleManager,
@@ -165,6 +171,7 @@ func main() {
 		changersAdl,
 		changersMc,
 		cfg.SspHttpClientTimeouts,
+		redisWriteErrorMonitor,
 	)
 
 	if err := routerServer.LoadNetset(cfg.AllowedIpDbPath); err != nil {

--- a/cmd/spp-adapter/main.go
+++ b/cmd/spp-adapter/main.go
@@ -12,14 +12,14 @@ import (
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/geoBadIp"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	httpServer "gitlab.com/twinbid-exchange/RTB-exchange/internal/http"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	redis_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/redis"
 	sppAdapter "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/sspAdapter/service"
 	sppAdapterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/sspAdapter/web"
 )
 
 func main() {
-	workAdl := false
-	workMc := false
+	workStatus := sppAdapterWeb.NewWorkStatus(false, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -63,12 +63,12 @@ func main() {
 
 	badIp, err := geoBadIp.NewBadIPService(cfg.GeoIpDbPath)
 	if err != nil {
-		log.Fatalf("failed to create bad ip service: %w", err)
+		log.Fatalf("failed to create bad ip service: %v", err)
 	}
 
 	geoIp, err := geoBadIp.NewGeoIPService(cfg.GeoIpDbPath)
 	if err != nil {
-		log.Fatalf("failed to create geo ip service: %w", err)
+		log.Fatalf("failed to create geo ip service: %v", err)
 	}
 
 	adapter := sppAdapter.NewSspAdapter(
@@ -98,8 +98,13 @@ func main() {
 	go s.StartAsync()
 	log.Println("⏰ Scheduler started (every 30 seconds)")
 
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("SSP adapter ORTB", func(count uint64) {
+		workStatus.StopAll()
+	})
+	redisWriteErrorMonitor.Start()
+
 	router := chi.NewRouter()
-	router.Use(httpServer.WorkSspAdapterMiddleware(&workAdl, &workMc))
+	router.Use(httpServer.WorkSspAdapterMiddleware(workStatus))
 	router = httpServer.InitHttpRouter(router)
 	sppAdapterWeb.InitHttpRoutes(
 		ctx,
@@ -117,10 +122,10 @@ func main() {
 		cfg.SspBanMcFeeds,
 		cfg.SspNatAdlFeeds,
 		cfg.SspNatMcFeeds,
-		&workAdl,
-		&workMc,
+		workStatus,
 		siteIdsAndDomains,
 		geoToLang,
+		redisWriteErrorMonitor,
 	)
 	log.Println("HTTP routes initialized")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,10 +114,11 @@ func (l *ListString) SetValue(value string) error {
 type BiddingEngineConfig struct {
 	HttpServer                          HttpServer
 	GrpcServer                          GrpcServer
-	ProfitPercent                       float32 `yaml:"PROFIT_PERCENT" env:"PROFIT_PERCENT" env-default:"0.2"`
-	SspGeoDspPercentsAdultFilePath      string  `yaml:"SSP_GEO_DSP_PERCENTS_ADULT_FILE_PATH" env:"SSP_GEO_DSP_PERCENTS_ADULT_FILE_PATH"`
-	SspGeoDspPercentsMainstreamFilePath string  `yaml:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH" env:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH"`
-	AdmDomain                           string  `yaml:"ADM_DOMAIN" env:"ADM_DOMAIN"`
+	ProfitPercent                       float32  `yaml:"PROFIT_PERCENT" env:"PROFIT_PERCENT" env-default:"0.2"`
+	SspGeoDspPercentsAdultFilePath      string   `yaml:"SSP_GEO_DSP_PERCENTS_ADULT_FILE_PATH" env:"SSP_GEO_DSP_PERCENTS_ADULT_FILE_PATH"`
+	SspGeoDspPercentsMainstreamFilePath string   `yaml:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH" env:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH"`
+	AdmDomain                           string   `yaml:"ADM_DOMAIN" env:"ADM_DOMAIN"`
+	SspAdapterWorkStatusURLs            []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS"`
 	RedisConfig
 }
 
@@ -147,8 +148,9 @@ type RouterConfig struct {
 
 	SspHttpClientTimeouts MapStringToDuration `yaml:"SSP_HTTP_CLIENT_TIMEOUT" env:"SSP_HTTP_CLIENT_TIMEOUT"`
 
-	MaxParallelRequests int  `yaml:"MAX_PARALLEL_REQUESTS" env:"MAX_PARALLEL_REQUESTS" env-default:"64"`
-	Debug               bool `yaml:"DEBUG" env:"DEBUG" env-default:"false"`
+	MaxParallelRequests      int      `yaml:"MAX_PARALLEL_REQUESTS" env:"MAX_PARALLEL_REQUESTS" env-default:"64"`
+	Debug                    bool     `yaml:"DEBUG" env:"DEBUG" env-default:"false"`
+	SspAdapterWorkStatusURLs []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS"`
 
 	RedisConfig
 }
@@ -196,13 +198,14 @@ type SppAdapterConfig struct {
 }
 
 type AdmAdapterConfig struct {
-	HttpServer   HttpServer
-	AdmTimeout   time.Duration `yaml:"ADM_TIMEOUT" env:"ADM_TIMEOUT"`
-	NurlTimeout  time.Duration `yaml:"NURL_TIMEOUT" env:"NURL_TIMEOUT"`
-	FullChain    string        `yaml:"FULLCHAIN_PEM" env:"FULLCHAIN_PEM"`
-	PrivKey      string        `yaml:"PRIVKEY_PEM" env:"PRIVKEY_PEM"`
-	RsaFullChain string        `yaml:"RSA_FULLCHAIN_PEM" env:"RSA_FULLCHAIN_PEM"`
-	RsaPrivKey   string        `yaml:"RSA_PRIVKEY_PEM" env:"RSA_PRIVKEY_PEM"`
+	HttpServer               HttpServer
+	AdmTimeout               time.Duration `yaml:"ADM_TIMEOUT" env:"ADM_TIMEOUT"`
+	NurlTimeout              time.Duration `yaml:"NURL_TIMEOUT" env:"NURL_TIMEOUT"`
+	FullChain                string        `yaml:"FULLCHAIN_PEM" env:"FULLCHAIN_PEM"`
+	PrivKey                  string        `yaml:"PRIVKEY_PEM" env:"PRIVKEY_PEM"`
+	RsaFullChain             string        `yaml:"RSA_FULLCHAIN_PEM" env:"RSA_FULLCHAIN_PEM"`
+	RsaPrivKey               string        `yaml:"RSA_PRIVKEY_PEM" env:"RSA_PRIVKEY_PEM"`
+	SspAdapterWorkStatusURLs []string      `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS"`
 
 	RedisConfig
 }
@@ -211,7 +214,8 @@ type KafkaLoaderConfig struct {
 	KafkaConfig
 	ClickhouseConfig
 	BatchRatioConfig
-	EmptyLoopPauseMS int `yaml:"EMPTY_LOOP_PAUSE_MS" env:"EMPTY_LOOP_PAUSE_MS" env-default:"200"`
+	EmptyLoopPauseMS         int      `yaml:"EMPTY_LOOP_PAUSE_MS" env:"EMPTY_LOOP_PAUSE_MS" env-default:"200"`
+	SspAdapterWorkStatusURLs []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS"`
 }
 
 type ClickhouseConfig struct {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,25 +18,16 @@ import (
 	sppAdapterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/sspAdapter/web"
 )
 
-func WorkSspAdapterMiddleware(workAdl, workMc *bool) func(http.Handler) http.Handler {
+func WorkSspAdapterMiddleware(workStatus *sppAdapterWeb.WorkStatus) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == sppAdapterWeb.GetWorkStatusUrl {
+			if strings.HasPrefix(r.URL.Path, sppAdapterWeb.GetWorkStatusUrl) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if r.URL.Path == sppAdapterWeb.PutWorkStatusUrl {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			if !*workAdl && r.URL.Path == sppAdapterWeb.PostBid_POP_ADL_V_2_5_URL {
-				http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-				return
-			}
-
-			if !*workMc && r.URL.Path == sppAdapterWeb.PostBid_POP_MC_V_2_5_URL {
+			work, err := workStatus.Get(r.URL.Path)
+			if err == nil && !work {
 				http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
 				return
 			}

--- a/internal/services/batch_ratio.go
+++ b/internal/services/batch_ratio.go
@@ -29,6 +29,7 @@ type LoaderControl struct {
 	mu      sync.RWMutex
 	running bool
 	notify  chan struct{}
+	onStart []func()
 
 	version uint64
 	changed chan struct{}
@@ -54,12 +55,27 @@ func (c *LoaderControl) Start() {
 		return
 	}
 
+	callbacks := append([]func(){}, c.onStart...)
+	for _, callback := range callbacks {
+		callback()
+	}
+
 	c.running = true
 	c.version++
 
 	close(c.notify)
 	close(c.changed)
 	c.changed = make(chan struct{})
+}
+
+func (c *LoaderControl) AddOnStart(callback func()) {
+	if callback == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onStart = append(c.onStart, callback)
 }
 
 func (c *LoaderControl) Stop() {

--- a/internal/services/bidEngine/web/v_2_5.go
+++ b/internal/services/bidEngine/web/v_2_5.go
@@ -12,6 +12,7 @@ import (
 	pb "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/bidEngine"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/types/ortb_V2_5"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/types"
 	clickhouse_types "gitlab.com/twinbid-exchange/RTB-exchange/internal/types/clickhouse"
 	"google.golang.org/grpc/codes"
@@ -28,6 +29,7 @@ type Server struct {
 	percentMap_adult           *map[string]map[string]map[string]*types.PercentAndBidfloor
 	percentMap_mainstream      *map[string]map[string]map[string]*types.PercentAndBidfloor
 	admDomain                  string
+	redisWriteErrorMonitor     *services.RedisWriteErrorMonitor
 
 	GetWinnerBidInternal_V_2_5 func(
 		ctx context.Context,
@@ -66,6 +68,7 @@ func NewServer(
 	percentMap_mainstream *map[string]map[string]map[string]*types.PercentAndBidfloor,
 
 	admDomain string,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) *Server {
 	return &Server{
 		ProfitPercent:              ProfitPercent,
@@ -77,6 +80,7 @@ func NewServer(
 		percentMap_adult:           percentMap_adult,
 		percentMap_mainstream:      percentMap_mainstream,
 		admDomain:                  admDomain,
+		redisWriteErrorMonitor:     redisWriteErrorMonitor,
 	}
 }
 
@@ -113,10 +117,12 @@ func (s *Server) GetWinnerBid_V2_5(
 	for _, uuid := range req.ImpIdUuid {
 		if err := utils.WriteWinStats(ctx, s.redisClients, uuid, clickhouseBid[uuid], req.Logged); err != nil {
 			log.Printf("failed to WriteJsonToRedis Bid BID_RESPONSE_WINNER in GetWinnerBidInternal: %v", err)
+			s.redisWriteErrorMonitor.Record(err)
 		}
 
 		if err := utils.AddUUIDToRedisSet(ctx, s.redisClients, s.redisSetOrtb, uuid, req.Logged); err != nil {
 			log.Printf("failed to add ORTB UUID to Redis set in GetWinnerBidInternal: %v", err)
+			s.redisWriteErrorMonitor.Record(err)
 		}
 	}
 

--- a/internal/services/dspRouter/web/v_2_5.go
+++ b/internal/services/dspRouter/web/v_2_5.go
@@ -23,6 +23,7 @@ import (
 	dspRouterGrpc "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/dspRouter"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/types/ortb_V2_5"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	sppAdapterWeb "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/sspAdapter/web"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,7 +38,8 @@ type Server struct {
 	dspEndpoints_adult_v_2_5      config.MapStringToString
 	dspEndpoints_mainstream_v_2_5 config.MapStringToString
 
-	redisClients []*redis.Client
+	redisClients           []*redis.Client
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor
 
 	clients map[string]*http.Client
 
@@ -82,6 +84,7 @@ func NewServer(
 	filterBoxChangerAdl *filter.ChangersBoxChanger,
 	filterBoxChangerMc *filter.ChangersBoxChanger,
 	configTimeouts config.MapStringToDuration,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) *Server {
 	rang := cidranger.NewPCTrieRanger()
 
@@ -92,6 +95,7 @@ func NewServer(
 		dspEndpoints_adult_v_2_5:      dspEndpoints_v_2_5,
 		dspEndpoints_mainstream_v_2_5: dspEndpoints_mainstream_v_2_5,
 		redisClients:                  redisClients,
+		redisWriteErrorMonitor:        redisWriteErrorMonitor,
 		clients:                       clients,
 		timeout:                       timeout,
 		bufferPool: sync.Pool{
@@ -397,7 +401,10 @@ func (s *Server) GetBids_V2_5(
 	}
 
 	for _, uuid := range req.ImpIdUuid {
-		writeBidResponsesToRedis(s.redisClients, uuid, clickResponses, req.Logged)
+		if err := writeBidResponsesToRedis(s.redisClients, uuid, clickResponses, req.Logged); err != nil {
+			log.Printf("failed to write bid responses to Redis: %v", err)
+			s.redisWriteErrorMonitor.Record(err)
+		}
 	}
 
 	responses := make(map[string]*ortb_V2_5.BidResponse)

--- a/internal/services/redis_error_monitor.go
+++ b/internal/services/redis_error_monitor.go
@@ -1,0 +1,124 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	RedisWriteErrorLogThresholdPerSec  = uint64(100)
+	RedisWriteErrorStopThresholdPerSec = uint64(800)
+
+	sspAdapterWorkStatusAllPath = "/work_status/all"
+)
+
+type RedisWriteErrorMonitor struct {
+	name     string
+	errors   atomic.Uint64
+	stopFunc func(uint64)
+}
+
+func NewRedisWriteErrorMonitor(name string, stopFunc func(uint64)) *RedisWriteErrorMonitor {
+	return &RedisWriteErrorMonitor{name: name, stopFunc: stopFunc}
+}
+
+func (m *RedisWriteErrorMonitor) Record(err error) {
+	if err == nil || m == nil {
+		return
+	}
+	m.errors.Add(1)
+}
+
+func (m *RedisWriteErrorMonitor) Start() {
+	if m == nil {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			count := m.errors.Swap(0)
+			if count >= RedisWriteErrorStopThresholdPerSec {
+				log.Printf("❌ %s Redis write errors reached %d requests/sec, stopping all SSP adapter ORTB streams", m.name, count)
+				if m.stopFunc != nil {
+					m.stopFunc(count)
+				}
+				continue
+			}
+
+			if count >= RedisWriteErrorLogThresholdPerSec {
+				log.Printf("❌ %s Redis write errors reached %d requests/sec", m.name, count)
+			}
+		}
+	}()
+}
+
+func StopAllSspAdapterOrtbStreams(ctx context.Context, workStatusURLs []string) {
+	if len(workStatusURLs) == 0 {
+		log.Printf("⚠️ SSP adapter stop URLs are not configured; cannot stop SSP adapter ORTB streams")
+		return
+	}
+
+	for _, rawURL := range workStatusURLs {
+		endpoint := strings.TrimSpace(rawURL)
+		if endpoint == "" {
+			continue
+		}
+
+		if err := stopSspAdapterAllStreams(ctx, endpoint); err != nil {
+			log.Printf("❌ failed to stop SSP adapter ORTB streams at %s: %v", endpoint, err)
+		}
+	}
+}
+
+func stopSspAdapterAllStreams(parent context.Context, endpoint string) error {
+	requestURL, err := buildSspAdapterStopAllURL(endpoint)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func buildSspAdapterStopAllURL(endpoint string) (string, error) {
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "http://" + endpoint
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	if u.Path == "" || u.Path == "/" || u.Path == "/work_status" {
+		u.Path = sspAdapterWorkStatusAllPath
+	}
+	q := u.Query()
+	q.Set("work", "false")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/services/resettable_once.go
+++ b/internal/services/resettable_once.go
@@ -1,0 +1,34 @@
+package services
+
+import "sync"
+
+type ResettableOnce struct {
+	mu   sync.Mutex
+	once *sync.Once
+}
+
+func NewResettableOnce() *ResettableOnce {
+	return &ResettableOnce{once: &sync.Once{}}
+}
+
+func (r *ResettableOnce) Do(f func()) {
+	if f == nil || r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	once := r.once
+	r.mu.Unlock()
+
+	once.Do(f)
+}
+
+func (r *ResettableOnce) Reset() {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.once = &sync.Once{}
+}

--- a/internal/services/resettable_once_test.go
+++ b/internal/services/resettable_once_test.go
@@ -1,0 +1,39 @@
+package services
+
+import "testing"
+
+func TestResettableOnceAllowsDoAfterReset(t *testing.T) {
+	once := NewResettableOnce()
+	calls := 0
+
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	if calls != 1 {
+		t.Fatalf("Do() before Reset() calls = %d, want 1", calls)
+	}
+
+	once.Reset()
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	if calls != 2 {
+		t.Fatalf("Do() after Reset() calls = %d, want 2", calls)
+	}
+}
+
+func TestLoaderControlAddOnStartRunsOnlyOnStoppedToRunningTransition(t *testing.T) {
+	control := NewLoaderControl(false)
+	calls := 0
+	control.AddOnStart(func() { calls++ })
+
+	control.Start()
+	control.Start()
+	if calls != 1 {
+		t.Fatalf("callbacks after duplicate Start() calls = %d, want 1", calls)
+	}
+
+	control.Stop()
+	control.Start()
+	if calls != 2 {
+		t.Fatalf("callbacks after Stop()+Start() = %d, want 2", calls)
+	}
+}

--- a/internal/services/sspAdapter/web/common.go
+++ b/internal/services/sspAdapter/web/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/constants"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 )
 
 func getAdm(
@@ -19,6 +20,7 @@ func getAdm(
 	r *http.Request,
 	redisClients []*redis.Client,
 	redisSetClicks string,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
 
@@ -31,8 +33,10 @@ func getAdm(
 
 	if err := utils.WriteStringToRedis(ctx, redisClients, input.GlobalId, constants.EVENT_TIME_CLICKS_COLUMN, time.Now().UTC().Format("2006-01-02 15:04:05.000"), true); err != nil {
 		log.Printf("failed to WriteStringToRedis EVENT_TIME_CLICKS_COLUMN in getAdm: %v", err)
+		redisWriteErrorMonitor.Record(err)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetClicks, input.GlobalId, true); err != nil {
 		log.Printf("failed to add click UUID to Redis set in getAdm: %v", err)
+		redisWriteErrorMonitor.Record(err)
 	}
 
 	http.Redirect(w, r, decodedURL, http.StatusFound)
@@ -44,6 +48,7 @@ func getNurl(
 	r *http.Request,
 	redisClients []*redis.Client,
 	redisSetImpressions string,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
 
@@ -56,8 +61,10 @@ func getNurl(
 
 	if err := utils.WriteStringToRedis(ctx, redisClients, input.GlobalId, constants.EVENT_TIME_IMPRESSIONS_COLUMN, time.Now().UTC().Format("2006-01-02 15:04:05.000"), true); err != nil {
 		log.Printf("failed to WriteStringToRedis EVENT_TIME_IMPRESSIONS_COLUMN in getAdm: %v", err)
+		redisWriteErrorMonitor.Record(err)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetImpressions, input.GlobalId, true); err != nil {
 		log.Printf("failed to add impression UUID to Redis set in getNurl: %v", err)
+		redisWriteErrorMonitor.Record(err)
 	}
 
 	http.Redirect(w, r, decodedURL, http.StatusFound)

--- a/internal/services/sspAdapter/web/route.go
+++ b/internal/services/sspAdapter/web/route.go
@@ -9,6 +9,7 @@ import (
 	orchestratorProto "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/orchestrator"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/types/ortb_V2_5"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 
 	"github.com/ggicci/httpin"
 	"github.com/ggicci/httpin/integration"
@@ -51,7 +52,16 @@ const (
 	GetNurlUrl = "/nurl"
 
 	GetWorkStatusUrl = "/work_status"
-	PutWorkStatusUrl = "/work_status"
+
+	PutWorkStatusAllUrl           = "/work_status/all"
+	PutWorkStatusPopAdultUrl      = "/work_status/pop_adl"
+	PutWorkStatusPopMainstreamUrl = "/work_status/pop_mc"
+	PutWorkStatusIppAdultUrl      = "/work_status/ipp_adl"
+	PutWorkStatusIppMainstreamUrl = "/work_status/ipp_mc"
+	PutWorkStatusBanAdultUrl      = "/work_status/ban_adl"
+	PutWorkStatusBanMainstreamUrl = "/work_status/ban_mc"
+	PutWorkStatusNatAdultUrl      = "/work_status/nat_adl"
+	PutWorkStatusNatMainstreamUrl = "/work_status/nat_mc"
 )
 
 type postBidRequest_V2_5 struct {
@@ -71,13 +81,18 @@ type admNurlRequest struct {
 }
 
 type putWorkStatusRequest struct {
-	Work  bool   `in:"query=work" required:"true"`
-	Typic string `in:"query=typic" required:"true"`
+	Work bool `in:"query=work" required:"true"`
 }
 
 type getWorkStatusResponse struct {
-	WorkAdl bool `json:"workAdl"`
-	WorkMc  bool `json:"workMc"`
+	PopAdult      bool `json:"popAdult"`
+	PopMainstream bool `json:"popMainstream"`
+	IppAdult      bool `json:"ippAdult"`
+	IppMainstream bool `json:"ippMainstream"`
+	BanAdult      bool `json:"banAdult"`
+	BanMainstream bool `json:"banMainstream"`
+	NatAdult      bool `json:"natAdult"`
+	NatMainstream bool `json:"natMainstream"`
 }
 
 func InitHttpRoutes(
@@ -96,10 +111,10 @@ func InitHttpRoutes(
 	sspFeedsBanMc map[string]string, // MAINSTREAM + BAN
 	sspFeedsNatAdl map[string]string, // ADULT + NAT
 	sspFeedsNatMc map[string]string, // MAINSTREAM + NAT
-	workAdl,
-	workMc *bool,
+	workStatus *WorkStatus,
 	siteIdsAndDomains *utils.SiteIdsAndDomains,
 	geoToLang geoBadIp.GeoToLang,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	var counter uint64 = 0
 	integration.UseGochiURLParam("path", chi.URLParam)
@@ -107,25 +122,65 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, POP, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, POP, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(putWorkStatusRequest{}),
-	).Put(PutWorkStatusUrl, func(w http.ResponseWriter, r *http.Request) {
-		putWorkStatus(w, r, workAdl, workMc)
+	).Put(PutWorkStatusAllUrl, func(w http.ResponseWriter, r *http.Request) {
+		putAllWorkStatus(w, r, workStatus)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusPopAdultUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_POP_ADL_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusPopMainstreamUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_POP_MC_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusIppAdultUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_IPP_ADL_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusIppMainstreamUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_IPP_MC_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusBanAdultUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_BAN_ADL_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusBanMainstreamUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_BAN_MC_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusNatAdultUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_NAT_ADL_V_2_5_URL)
+	})
+	httpRouter.With(
+		httpin.NewInput(putWorkStatusRequest{}),
+	).Put(PutWorkStatusNatMainstreamUrl, func(w http.ResponseWriter, r *http.Request) {
+		putWorkStatus(w, r, workStatus, PostBid_NAT_MC_V_2_5_URL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(getWorkStatusResponse{}),
 	).Get(GetWorkStatusUrl, func(w http.ResponseWriter, r *http.Request) {
-		getWorkStatus(w, workAdl, workMc)
+		getWorkStatus(w, workStatus)
 	})
 
 	//---------------------------------------------------------------
@@ -133,13 +188,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, IPP, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, IPP, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	//---------------------------------------------------------------
@@ -147,13 +202,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, BAN, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, BAN, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	//---------------------------------------------------------------
@@ -161,13 +216,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, NAT, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, NAT, siteIdsAndDomains, geoToLang)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
 	})
 }
 
@@ -180,18 +235,19 @@ func InitHttpsRoutes(
 	redisSetClicks string,
 	admTimeout,
 	nurlTimeout time.Duration,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	integration.UseGochiURLParam("path", chi.URLParam)
 
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
 	).Get(GetAdmUrl, func(w http.ResponseWriter, r *http.Request) {
-		getAdm(ctx, w, r, redisClientsClicks, redisSetClicks)
+		getAdm(ctx, w, r, redisClientsClicks, redisSetClicks, redisWriteErrorMonitor)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
 	).Get(GetNurlUrl, func(w http.ResponseWriter, r *http.Request) {
-		getNurl(ctx, w, r, redisClientsImp, redisSetImpressions)
+		getNurl(ctx, w, r, redisClientsImp, redisSetImpressions, redisWriteErrorMonitor)
 	})
 }

--- a/internal/services/sspAdapter/web/v_2_5.go
+++ b/internal/services/sspAdapter/web/v_2_5.go
@@ -17,6 +17,7 @@ import (
 	orchestratorProto "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/services/orchestrator"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/types/ortb_V2_5"
 	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
+	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/ua"
 	"google.golang.org/grpc/status"
 )
@@ -42,6 +43,7 @@ func postBid_V2_5(
 	format string,
 	siteIdsAndDomains *utils.SiteIdsAndDomains,
 	geoToLang geoBadIp.GeoToLang,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	var input *postBidRequest_V2_5
 	defer func() {
@@ -150,7 +152,7 @@ func postBid_V2_5(
 	}
 
 	countryISO, cityId, err := getCountryISO(input.Payload.BidRequest.Device.GetIp())
-	if errors.As(err, geoBadIp.BadIpFormatError) {
+	if errors.Is(err, geoBadIp.BadIpFormatError) {
 		err := fmt.Errorf(
 			"Bad format: %w",
 			err,
@@ -158,7 +160,7 @@ func postBid_V2_5(
 		log.Print(err.Error(), r.RemoteAddr)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
-	} else if errors.As(err, geoBadIp.InnerLookupIpError) {
+	} else if errors.Is(err, geoBadIp.InnerLookupIpError) {
 		err := fmt.Errorf(
 			"There an server error while getCountryISO: %w",
 			err,
@@ -259,6 +261,7 @@ func postBid_V2_5(
 			float64(input.Payload.Imp[i].GetBidfloor()),
 		); err != nil {
 			log.Printf("failed to WriteStats in postBid_V2_5: %v", err)
+			redisWriteErrorMonitor.Record(err)
 		}
 	}
 
@@ -305,12 +308,26 @@ func postBid_V2_5(
 
 func getWorkStatus(
 	w http.ResponseWriter,
-	workAdl,
-	workMc *bool,
+	workStatus *WorkStatus,
 ) {
+	popAdult, _ := workStatus.Get(PostBid_POP_ADL_V_2_5_URL)
+	popMainstream, _ := workStatus.Get(PostBid_POP_MC_V_2_5_URL)
+	ippAdult, _ := workStatus.Get(PostBid_IPP_ADL_V_2_5_URL)
+	ippMainstream, _ := workStatus.Get(PostBid_IPP_MC_V_2_5_URL)
+	banAdult, _ := workStatus.Get(PostBid_BAN_ADL_V_2_5_URL)
+	banMainstream, _ := workStatus.Get(PostBid_BAN_MC_V_2_5_URL)
+	natAdult, _ := workStatus.Get(PostBid_NAT_ADL_V_2_5_URL)
+	natMainstream, _ := workStatus.Get(PostBid_NAT_MC_V_2_5_URL)
+
 	if err := rnr.JSON(w, http.StatusOK, getWorkStatusResponse{
-		WorkAdl: *workAdl,
-		WorkMc:  *workMc,
+		PopAdult:      popAdult,
+		PopMainstream: popMainstream,
+		IppAdult:      ippAdult,
+		IppMainstream: ippMainstream,
+		BanAdult:      banAdult,
+		BanMainstream: banMainstream,
+		NatAdult:      natAdult,
+		NatMainstream: natMainstream,
 	}); err != nil {
 		log.Printf("Cannot make HTTP response back in getWorkStatus: %v\n", err)
 	}
@@ -319,24 +336,30 @@ func getWorkStatus(
 func putWorkStatus(
 	w http.ResponseWriter,
 	r *http.Request,
-	workAdl,
-	workMc *bool,
+	workStatus *WorkStatus,
+	streamURL string,
 ) {
 	input := r.Context().Value(httpin.Input).(*putWorkStatusRequest)
 
-	var work bool
-	switch input.Typic {
-	case ADULT:
-		*workAdl = input.Work
-		work = *workAdl
-	case MAINSTREAM:
-		*workMc = input.Work
-		work = *workMc
-	default:
-		http.Error(w, "Typic is no here", http.StatusBadRequest)
+	if err := workStatus.Set(streamURL, input.Work); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	if err := rnr.Text(w, http.StatusOK, fmt.Sprintf("Changed to %v", work)); err != nil {
+	if err := rnr.Text(w, http.StatusOK, fmt.Sprintf("Changed %s to %v", streamURL, input.Work)); err != nil {
 		log.Printf("Cannot make HTTP response back in putWorkStatus: %v\n", err)
+	}
+}
+
+func putAllWorkStatus(
+	w http.ResponseWriter,
+	r *http.Request,
+	workStatus *WorkStatus,
+) {
+	input := r.Context().Value(httpin.Input).(*putWorkStatusRequest)
+	workStatus.SetAll(input.Work)
+
+	if err := rnr.Text(w, http.StatusOK, fmt.Sprintf("Changed all ORTB streams to %v", input.Work)); err != nil {
+		log.Printf("Cannot make HTTP response back in putAllWorkStatus: %v\n", err)
 	}
 }

--- a/internal/services/sspAdapter/web/work_status.go
+++ b/internal/services/sspAdapter/web/work_status.go
@@ -1,0 +1,92 @@
+package sppAdapterWeb
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+type WorkStatus struct {
+	popAdult      atomic.Bool
+	popMainstream atomic.Bool
+	ippAdult      atomic.Bool
+	ippMainstream atomic.Bool
+	banAdult      atomic.Bool
+	banMainstream atomic.Bool
+	natAdult      atomic.Bool
+	natMainstream atomic.Bool
+}
+
+func NewWorkStatus(workAdult, workMainstream bool) *WorkStatus {
+	status := &WorkStatus{}
+	status.Set(PostBid_POP_ADL_V_2_5_URL, workAdult)
+	status.Set(PostBid_IPP_ADL_V_2_5_URL, workAdult)
+	status.Set(PostBid_BAN_ADL_V_2_5_URL, workAdult)
+	status.Set(PostBid_NAT_ADL_V_2_5_URL, workAdult)
+	status.Set(PostBid_POP_MC_V_2_5_URL, workMainstream)
+	status.Set(PostBid_IPP_MC_V_2_5_URL, workMainstream)
+	status.Set(PostBid_BAN_MC_V_2_5_URL, workMainstream)
+	status.Set(PostBid_NAT_MC_V_2_5_URL, workMainstream)
+	return status
+}
+
+func (s *WorkStatus) Get(stream string) (bool, error) {
+	switch stream {
+	case PostBid_POP_ADL_V_2_5_URL:
+		return s.popAdult.Load(), nil
+	case PostBid_POP_MC_V_2_5_URL:
+		return s.popMainstream.Load(), nil
+	case PostBid_IPP_ADL_V_2_5_URL:
+		return s.ippAdult.Load(), nil
+	case PostBid_IPP_MC_V_2_5_URL:
+		return s.ippMainstream.Load(), nil
+	case PostBid_BAN_ADL_V_2_5_URL:
+		return s.banAdult.Load(), nil
+	case PostBid_BAN_MC_V_2_5_URL:
+		return s.banMainstream.Load(), nil
+	case PostBid_NAT_ADL_V_2_5_URL:
+		return s.natAdult.Load(), nil
+	case PostBid_NAT_MC_V_2_5_URL:
+		return s.natMainstream.Load(), nil
+	default:
+		return false, fmt.Errorf("unknown ORTB stream url %q", stream)
+	}
+}
+
+func (s *WorkStatus) Set(stream string, work bool) error {
+	switch stream {
+	case PostBid_POP_ADL_V_2_5_URL:
+		s.popAdult.Store(work)
+	case PostBid_POP_MC_V_2_5_URL:
+		s.popMainstream.Store(work)
+	case PostBid_IPP_ADL_V_2_5_URL:
+		s.ippAdult.Store(work)
+	case PostBid_IPP_MC_V_2_5_URL:
+		s.ippMainstream.Store(work)
+	case PostBid_BAN_ADL_V_2_5_URL:
+		s.banAdult.Store(work)
+	case PostBid_BAN_MC_V_2_5_URL:
+		s.banMainstream.Store(work)
+	case PostBid_NAT_ADL_V_2_5_URL:
+		s.natAdult.Store(work)
+	case PostBid_NAT_MC_V_2_5_URL:
+		s.natMainstream.Store(work)
+	default:
+		return fmt.Errorf("unknown ORTB stream url %q", stream)
+	}
+	return nil
+}
+
+func (s *WorkStatus) SetAll(work bool) {
+	s.popAdult.Store(work)
+	s.popMainstream.Store(work)
+	s.ippAdult.Store(work)
+	s.ippMainstream.Store(work)
+	s.banAdult.Store(work)
+	s.banMainstream.Store(work)
+	s.natAdult.Store(work)
+	s.natMainstream.Store(work)
+}
+
+func (s *WorkStatus) StopAll() {
+	s.SetAll(false)
+}

--- a/internal/services/sspAdapter/web/work_status_test.go
+++ b/internal/services/sspAdapter/web/work_status_test.go
@@ -1,0 +1,51 @@
+package sppAdapterWeb
+
+import "testing"
+
+func TestWorkStatusControlsStreamsIndependently(t *testing.T) {
+	status := NewWorkStatus(false, false)
+
+	if err := status.Set(PostBid_POP_ADL_V_2_5_URL, true); err != nil {
+		t.Fatalf("Set(%s) error = %v", PostBid_POP_ADL_V_2_5_URL, err)
+	}
+
+	popAdult, err := status.Get(PostBid_POP_ADL_V_2_5_URL)
+	if err != nil {
+		t.Fatalf("Get(%s) error = %v", PostBid_POP_ADL_V_2_5_URL, err)
+	}
+	banAdult, err := status.Get(PostBid_BAN_ADL_V_2_5_URL)
+	if err != nil {
+		t.Fatalf("Get(%s) error = %v", PostBid_BAN_ADL_V_2_5_URL, err)
+	}
+
+	if !popAdult {
+		t.Fatalf("%s = false, want true", PostBid_POP_ADL_V_2_5_URL)
+	}
+	if banAdult {
+		t.Fatalf("%s = true, want false", PostBid_BAN_ADL_V_2_5_URL)
+	}
+}
+
+func TestWorkStatusSetAllSetsEveryStream(t *testing.T) {
+	status := NewWorkStatus(false, false)
+	status.SetAll(true)
+
+	for _, stream := range []string{
+		PostBid_POP_ADL_V_2_5_URL,
+		PostBid_POP_MC_V_2_5_URL,
+		PostBid_IPP_ADL_V_2_5_URL,
+		PostBid_IPP_MC_V_2_5_URL,
+		PostBid_BAN_ADL_V_2_5_URL,
+		PostBid_BAN_MC_V_2_5_URL,
+		PostBid_NAT_ADL_V_2_5_URL,
+		PostBid_NAT_MC_V_2_5_URL,
+	} {
+		work, err := status.Get(stream)
+		if err != nil {
+			t.Fatalf("Get(%s) error = %v", stream, err)
+		}
+		if !work {
+			t.Fatalf("%s = false, want true", stream)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation

- Detect high rates of Redis write errors and automatically stop SSP adapter ORTB streams to prevent cascading failures. 
- Provide per-stream and global control for SSP adapter ORTB work status via HTTP endpoints and middleware. 
- Allow loader control callbacks to run when batch processing is started and make stream error handling reusable. 

### Description

- Introduced a `RedisWriteErrorMonitor` in `internal/services/redis_error_monitor.go` with thresholds and `StopAllSspAdapterOrtbStreams` to call configured SSP adapter URLs when the error rate is high, and added `Record`/`Start` usage sites across services. 
- Added a `WorkStatus` type for SSP adapter ORTB streams in `internal/services/sspAdapter/web/work_status.go`, replaced the previous boolean flags, added per-stream and "all" HTTP endpoints, updated middleware to use `WorkStatus`, and wired these routes in `internal/services/sspAdapter/web/route.go` and `internal/http/server.go`. 
- Propagated the `RedisWriteErrorMonitor` into `bid-engine`, `router`, `adm-adapter`, `spp-adapter` and relevant web/server constructors and handlers so write errors call `Record` and may trigger stream stops. 
- Added `ResettableOnce` (`internal/services/resettable_once.go`) and tests, and added `LoaderControl.AddOnStart` and callback invocation in `internal/services/batch_ratio.go` so loader start events can trigger one-shot actions. 
- Unified and extracted stream error handlers in `kafka-loader` and `clickhouse-loader` to call `loaderControl.Stop()` and (for Kafka loader) stop SSP ORTB streams once via a resettable once. 
- Updated config structs in `internal/config/config.go` to include `SspAdapterWorkStatusURLs` for services that need to call SSP adapters, and minor error/log formatting fixes. 

### Testing

- Added unit tests `internal/services/resettable_once_test.go` and `internal/services/sspAdapter/web/work_status_test.go`. 
- Ran `go test ./...` against the modified packages and the new tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2945f6d6108328b5a3a9fdae165552)