### PR TITLE
Propagate `format` field through events pipeline (proto, Redis, Kafka, ClickHouse, ssp adapter)

### DIFF
--- a/internal/grpc/proto/buffer/buffer.pb.go
+++ b/internal/grpc/proto/buffer/buffer.pb.go
@@ -305,6 +305,7 @@ type ImpressionEvent struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	Uuid                   string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	EventTimeImpressionsMs int64                  `protobuf:"varint,2,opt,name=event_time_impressions_ms,json=eventTimeImpressionsMs,proto3" json:"event_time_impressions_ms,omitempty"`
+	Format                 string                 `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -353,10 +354,18 @@ func (x *ImpressionEvent) GetEventTimeImpressionsMs() int64 {
 	return 0
 }
 
+func (x *ImpressionEvent) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
 type ClickEvent struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Uuid              string                 `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	EventTimeClicksMs int64                  `protobuf:"varint,2,opt,name=event_time_clicks_ms,json=eventTimeClicksMs,proto3" json:"event_time_clicks_ms,omitempty"`
+	Format            string                 `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -405,6 +414,13 @@ func (x *ClickEvent) GetEventTimeClicksMs() int64 {
 	return 0
 }
 
+func (x *ClickEvent) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
 var File_buffer_buffer_proto protoreflect.FileDescriptor
 
 const file_buffer_buffer_proto_rawDesc = "" +
@@ -448,14 +464,16 @@ const file_buffer_buffer_proto_rawDesc = "" +
 	"\vwin_user_id\x18\x19 \x01(\tR\twinUserId\x1a?\n" +
 	"\x11BidResponsesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"`\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"x\n" +
 	"\x0fImpressionEvent\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x129\n" +
-	"\x19event_time_impressions_ms\x18\x02 \x01(\x03R\x16eventTimeImpressionsMs\"Q\n" +
+	"\x19event_time_impressions_ms\x18\x02 \x01(\x03R\x16eventTimeImpressionsMs\x12\x16\n" +
+	"\x06format\x18\x03 \x01(\tR\x06format\"i\n" +
 	"\n" +
 	"ClickEvent\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12/\n" +
-	"\x14event_time_clicks_ms\x18\x02 \x01(\x03R\x11eventTimeClicksMsBNZLgitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/buffer;eventspbb\x06proto3"
+	"\x14event_time_clicks_ms\x18\x02 \x01(\x03R\x11eventTimeClicksMs\x12\x16\n" +
+	"\x06format\x18\x03 \x01(\tR\x06formatBNZLgitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/proto/buffer;eventspbb\x06proto3"
 
 var (
 	file_buffer_buffer_proto_rawDescOnce sync.Once

--- a/internal/grpc/utils_grpc/redisWrirter.go
+++ b/internal/grpc/utils_grpc/redisWrirter.go
@@ -227,3 +227,69 @@ func WriteStatsOrtb(
 
 	return nil
 }
+
+// WriteClickStats записывает статистику клика в Redis одним HSET.
+func WriteClickStats(
+	ctx context.Context,
+	redisClients []*redis.Client,
+	globalId string,
+	format string,
+	logged bool,
+) error {
+	if !logged {
+		return nil
+	}
+
+	client, idx, err := redis_service.SelectShard(redisClients, globalId)
+	if err != nil {
+		return fmt.Errorf("failed to select shard for uuid %s: %w", globalId, err)
+	}
+
+	fields := map[string]interface{}{
+		constants.EVENT_TIME_CLICKS_COLUMN: time.Now().UTC().Format("2006-01-02 15:04:05.000"),
+		constants.FORMAT_COLUMN:            format,
+	}
+
+	pipe := client.Pipeline()
+	pipe.HSet(ctx, globalId, fields)
+	pipe.Expire(ctx, globalId, RedisKeyTTL)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to write click stats to Redis (uuid=%s, shard=%d): %w", globalId, idx, err)
+	}
+
+	return nil
+}
+
+// WriteImpressionStats записывает статистику показа в Redis одним HSET.
+func WriteImpressionStats(
+	ctx context.Context,
+	redisClients []*redis.Client,
+	globalId string,
+	format string,
+	logged bool,
+) error {
+	if !logged {
+		return nil
+	}
+
+	client, idx, err := redis_service.SelectShard(redisClients, globalId)
+	if err != nil {
+		return fmt.Errorf("failed to select shard for uuid %s: %w", globalId, err)
+	}
+
+	fields := map[string]interface{}{
+		constants.EVENT_TIME_IMPRESSIONS_COLUMN: time.Now().UTC().Format("2006-01-02 15:04:05.000"),
+		constants.FORMAT_COLUMN:                 format,
+	}
+
+	pipe := client.Pipeline()
+	pipe.HSet(ctx, globalId, fields)
+	pipe.Expire(ctx, globalId, RedisKeyTTL)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to write impression stats to Redis (uuid=%s, shard=%d): %w", globalId, idx, err)
+	}
+
+	return nil
+}

--- a/internal/services/clickhouse-loader/clicks.go
+++ b/internal/services/clickhouse-loader/clicks.go
@@ -106,7 +106,8 @@ func insertBatchClicks(
 	query := fmt.Sprintf(`
 		INSERT INTO %s (
 			uuid,
-			event_time_clicks
+			event_time_clicks,
+			format
 		)
 	`, table)
 
@@ -124,7 +125,7 @@ func insertBatchClicks(
 
 		ts := time.UnixMilli(r.EventTimeClicksMs).UTC()
 
-		if err := batch.Append(u, ts); err != nil {
+		if err := batch.Append(u, ts, r.Format); err != nil {
 			return fmt.Errorf("batch.Append: %w", err)
 		}
 	}

--- a/internal/services/clickhouse-loader/createDb.go
+++ b/internal/services/clickhouse-loader/createDb.go
@@ -81,6 +81,8 @@ CREATE TABLE IF NOT EXISTS {db}.impressions_in
     event_time_impressions DateTime64(3, 'UTC') DEFAULT now64(3),
     created_at             DateTime64(3, 'UTC') DEFAULT now64(3),
 
+    format                 LowCardinality(String) DEFAULT '',
+
     uuid UUID
 )
 ENGINE = MergeTree
@@ -92,6 +94,8 @@ CREATE TABLE IF NOT EXISTS {db}.clicks_in
 (
     event_time_clicks DateTime64(3, 'UTC') DEFAULT now64(3),
     created_at        DateTime64(3, 'UTC') DEFAULT now64(3),
+
+    format            LowCardinality(String) DEFAULT '',
 
     uuid UUID
 )

--- a/internal/services/clickhouse-loader/impressions.go
+++ b/internal/services/clickhouse-loader/impressions.go
@@ -106,7 +106,8 @@ func insertBatchImpressions(
 	query := fmt.Sprintf(`
 		INSERT INTO %s (
 			uuid,
-			event_time_impressions
+			event_time_impressions,
+			format
 		)
 	`, table)
 
@@ -124,7 +125,7 @@ func insertBatchImpressions(
 
 		ts := time.UnixMilli(r.EventTimeImpressionsMs).UTC()
 
-		if err := batch.Append(u, ts); err != nil {
+		if err := batch.Append(u, ts, r.Format); err != nil {
 			return fmt.Errorf("batch.Append: %w", err)
 		}
 	}

--- a/internal/services/kafka-loader/clicks.go
+++ b/internal/services/kafka-loader/clicks.go
@@ -92,7 +92,7 @@ func processClicksShard(
 	cmds := make([]*redis.SliceCmd, 0, len(uuids))
 
 	for _, uuid := range uuids {
-		cmds = append(cmds, readPipe.HMGet(ctx, uuid, constants.EVENT_TIME_CLICKS_COLUMN))
+		cmds = append(cmds, readPipe.HMGet(ctx, uuid, constants.EVENT_TIME_CLICKS_COLUMN, constants.FORMAT_COLUMN))
 	}
 
 	if _, err := readPipe.Exec(ctx); err != nil {
@@ -111,10 +111,12 @@ func processClicksShard(
 
 		key := uuids[i]
 		eventTime := valueAsString(values, 0)
+		format := valueAsString(values, 1)
 
 		rawRecord := types.Clicks{
 			UUID:              key,
 			EVENT_TIME_CLICKS: eventTime,
+			FORMAT:            format,
 		}
 
 		if !types.HasDataClicks(rawRecord) {
@@ -124,6 +126,7 @@ func processClicksShard(
 		record := &eventspb.ClickEvent{
 			Uuid:              rawRecord.UUID,
 			EventTimeClicksMs: parseUnixMsSafe(rawRecord.EVENT_TIME_CLICKS),
+			Format:            rawRecord.FORMAT,
 		}
 
 		protoData, err := proto.Marshal(record)

--- a/internal/services/kafka-loader/impressions.go
+++ b/internal/services/kafka-loader/impressions.go
@@ -92,7 +92,7 @@ func processImpressionsShard(
 	cmds := make([]*redis.SliceCmd, 0, len(uuids))
 
 	for _, uuid := range uuids {
-		cmds = append(cmds, readPipe.HMGet(ctx, uuid, constants.EVENT_TIME_IMPRESSIONS_COLUMN))
+		cmds = append(cmds, readPipe.HMGet(ctx, uuid, constants.EVENT_TIME_IMPRESSIONS_COLUMN, constants.FORMAT_COLUMN))
 	}
 
 	if _, err := readPipe.Exec(ctx); err != nil {
@@ -111,10 +111,12 @@ func processImpressionsShard(
 
 		key := uuids[i]
 		eventTime := valueAsString(values, 0)
+		format := valueAsString(values, 1)
 
 		rawRecord := types.Impressions{
 			UUID:                   key,
 			EVENT_TIME_IMPRESSIONS: eventTime,
+			FORMAT:                 format,
 		}
 
 		if !types.HasDataImpressions(rawRecord) {
@@ -124,6 +126,7 @@ func processImpressionsShard(
 		record := &eventspb.ImpressionEvent{
 			Uuid:                   rawRecord.UUID,
 			EventTimeImpressionsMs: parseUnixMsSafe(rawRecord.EVENT_TIME_IMPRESSIONS),
+			Format:                 rawRecord.FORMAT,
 		}
 
 		protoData, err := proto.Marshal(record)

--- a/internal/services/sspAdapter/web/common.go
+++ b/internal/services/sspAdapter/web/common.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/ggicci/httpin"
 	"github.com/redis/go-redis/v9"
@@ -23,6 +22,12 @@ func getAdm(
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
+	format, ok := constants.CodeToFormat[input.Format]
+	if !ok {
+		log.Printf("in getAdm invalid format code: %q", input.Format)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	decodedURL, err := url.QueryUnescape(input.DspURL)
 	if err != nil {
@@ -31,8 +36,8 @@ func getAdm(
 		return
 	}
 
-	if err := utils.WriteStringToRedis(ctx, redisClients, input.GlobalId, constants.EVENT_TIME_CLICKS_COLUMN, time.Now().UTC().Format("2006-01-02 15:04:05.000"), true); err != nil {
-		log.Printf("failed to WriteStringToRedis EVENT_TIME_CLICKS_COLUMN in getAdm: %v", err)
+	if err := utils.WriteClickStats(ctx, redisClients, input.GlobalId, format, true); err != nil {
+		log.Printf("failed to WriteClickStats in getAdm: %v", err)
 		redisWriteErrorMonitor.Record(err)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetClicks, input.GlobalId, true); err != nil {
 		log.Printf("failed to add click UUID to Redis set in getAdm: %v", err)
@@ -51,6 +56,12 @@ func getNurl(
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
+	format, ok := constants.CodeToFormat[input.Format]
+	if !ok {
+		log.Printf("in getNurl invalid format code: %q", input.Format)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	decodedURL, err := url.QueryUnescape(input.DspURL)
 	if err != nil {
@@ -59,8 +70,8 @@ func getNurl(
 		return
 	}
 
-	if err := utils.WriteStringToRedis(ctx, redisClients, input.GlobalId, constants.EVENT_TIME_IMPRESSIONS_COLUMN, time.Now().UTC().Format("2006-01-02 15:04:05.000"), true); err != nil {
-		log.Printf("failed to WriteStringToRedis EVENT_TIME_IMPRESSIONS_COLUMN in getAdm: %v", err)
+	if err := utils.WriteImpressionStats(ctx, redisClients, input.GlobalId, format, true); err != nil {
+		log.Printf("failed to WriteImpressionStats in getNurl: %v", err)
 		redisWriteErrorMonitor.Record(err)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetImpressions, input.GlobalId, true); err != nil {
 		log.Printf("failed to add impression UUID to Redis set in getNurl: %v", err)

--- a/internal/services/sspAdapter/web/route.go
+++ b/internal/services/sspAdapter/web/route.go
@@ -72,6 +72,7 @@ type postBidResponse_V2_5 struct {
 type admNurlRequest struct {
 	GlobalId string `in:"query=id" required:"true"`
 	DspURL   string `in:"query=url" required:"true"`
+	Format   string `in:"query=f" required:"true"`
 }
 
 type putWorkStatusRequest struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -31,11 +31,13 @@ type Ortb struct {
 type Clicks struct {
 	UUID              string `json:"UUID"`
 	EVENT_TIME_CLICKS string `json:"EVENT_TIME_CLICKS"`
+	FORMAT            string `json:"FORMAT"`
 }
 
 type Impressions struct {
 	UUID                   string `json:"UUID"`
 	EVENT_TIME_IMPRESSIONS string `json:"EVENT_TIME_IMPRESSIONS"`
+	FORMAT                 string `json:"FORMAT"`
 }
 
 type PercentAndBidfloor struct {
@@ -73,10 +75,12 @@ func HasDataOrtb(record Ortb) bool {
 
 func HasDataClicks(record Clicks) bool {
 	return record.UUID != "" ||
-		record.EVENT_TIME_CLICKS != ""
+		record.EVENT_TIME_CLICKS != "" ||
+		record.FORMAT != ""
 }
 
 func HasDataImpressions(record Impressions) bool {
 	return record.UUID != "" ||
-		record.EVENT_TIME_IMPRESSIONS != ""
+		record.EVENT_TIME_IMPRESSIONS != "" ||
+		record.FORMAT != ""
 }

--- a/proto/buffer/buffer.proto
+++ b/proto/buffer/buffer.proto
@@ -47,9 +47,11 @@ message OrtbEvent {
 message ImpressionEvent {
   string uuid = 1;
   int64 event_time_impressions_ms = 2;
+  string format = 3;
 }
 
 message ClickEvent {
   string uuid = 1;
   int64 event_time_clicks_ms = 2;
+  string format = 3;
 }


### PR DESCRIPTION
### Motivation
- Add a `format` attribute to impressions, clicks and ORTB events so ad format can be tracked throughout the processing pipeline.

### Description
- Extend the Protobuf schema by adding `format` to `ImpressionEvent` and `ClickEvent` in `proto/buffer/buffer.proto` and regenerate `buffer.pb.go` with accessors.
- Persist `format` to Redis by adding `WriteClickStats` and `WriteImpressionStats` in `internal/grpc/utils_grpc/redisWrirter.go` and replace the previous direct time-only writes in the SSP handlers with calls to these functions.
- Surface the format in the SSP HTTP layer by adding a `Format` query parameter to `admNurlRequest`, validating it via `constants.CodeToFormat`, and passing the resolved format to Redis writers in `internal/services/sspAdapter/web/common.go` and `route.go`.
- Read the `FORMAT_COLUMN` from Redis in both click and impression Kafka loaders (`internal/services/kafka-loader/clicks.go` and `impressions.go`), include it in `types.Clicks`/`types.Impressions`, and populate the generated protobuf messages with `Format`.
- Propagate `format` to ClickHouse by adding `format` columns to `clicks_in` and `impressions_in` and including `format` in `fact_impressions` in `internal/services/clickhouse-loader/createDb.go`, and update batch insert functions (`insertBatchClicks` and `insertBatchImpressions`) to append `r.Format` to prepared batches.
- Add `FORMAT` fields to the in-memory record types in `internal/types/types.go` and update `HasDataClicks`/`HasDataImpressions` to consider `FORMAT` when deciding if a record has data.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5401afd88328bd026f646b6643c4)