### PR TITLE
Add bot notifications to Redis write error monitor and propagate SSP work-status URL

### DIFF
--- a/cmd/adm-adapter/main.go
+++ b/cmd/adm-adapter/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/config"
+	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	httpServer "gitlab.com/twinbid-exchange/RTB-exchange/internal/http"
 	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	redis_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/redis"
@@ -84,9 +85,9 @@ func main() {
 	}
 	log.Println("✅ Connected to ADM/NURL Redis")
 
-	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("adm-adapter", func(count uint64) {
-		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
-	})
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("adm-adapter", func(count uint64, workStatusURL string) {
+		services.StopSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURL)
+	}, utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret), ctx)
 	redisWriteErrorMonitor.Start()
 
 	router := httpServer.InitHttpRouter(chi.NewRouter())
@@ -102,6 +103,7 @@ func main() {
 		cfg.AdmTimeout,
 		cfg.NurlTimeout,
 		redisWriteErrorMonitor,
+		cfg.SspAdapterWorkStatusURL,
 	)
 	log.Println("HTTP routes initialized")
 

--- a/cmd/bid-engine/main.go
+++ b/cmd/bid-engine/main.go
@@ -111,9 +111,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("bid-engine", func(count uint64) {
-		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
-	})
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("bid-engine", func(count uint64, workStatusURL string) {
+		services.StopSspAdapterOrtbStreams(ctx, workStatusURL)
+	}, utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret), ctx)
 	redisWriteErrorMonitor.Start()
 
 	s := grpc.NewServer()

--- a/cmd/clickhouse-loader/main.go
+++ b/cmd/clickhouse-loader/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/config"
+	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	clickhouse_loader "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/clickhouse-loader"
 	kafka_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/kafka"
@@ -129,8 +131,13 @@ func main() {
 	}
 
 	var loaderWG sync.WaitGroup
+	botNotifier := utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret)
 	handleStreamError := func(err error) {
-		log.Printf("❌ ClickHouse Loader stream error, stopping batch processing: %v", err)
+		message := fmt.Sprintf("❌ service=ClickHouse Loader stream error, stopping batch processing: %v", err)
+		log.Print(message)
+		if err := botNotifier.SendTextMessageToBot(ctx, message); err != nil {
+			log.Printf("❌ failed to send bot notification: %v", err)
+		}
 		loaderControl.Stop()
 	}
 	emptyPause := time.Duration(cfg.EmptyLoopPauseMS) * time.Millisecond

--- a/cmd/kafka-loader/main.go
+++ b/cmd/kafka-loader/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/config"
+	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 	services "gitlab.com/twinbid-exchange/RTB-exchange/internal/services"
 	kafka_service "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/kafka"
 	kafka_loader "gitlab.com/twinbid-exchange/RTB-exchange/internal/services/kafka-loader"
@@ -126,8 +128,13 @@ func main() {
 	}
 
 	var loaderWG sync.WaitGroup
+	botNotifier := utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret)
 	handleStreamError := func(err error) {
-		log.Printf("❌ Kafka Loader stream error, stopping batch processing and SSP adapter ORTB streams: %v", err)
+		message := fmt.Sprintf("❌ service=Kafka Loader stream error, stopping batch processing and SSP adapter ORTB streams: %v", err)
+		log.Print(message)
+		if err := botNotifier.SendTextMessageToBot(ctx, message); err != nil {
+			log.Printf("❌ failed to send bot notification: %v", err)
+		}
 		loaderControl.Stop()
 		stopSspOnce.Do(func() {
 			services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -147,9 +147,10 @@ func main() {
 		log.Fatalf("Failed to InitCidSspDspMap: %v", err)
 	}
 
-	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("router", func(count uint64) {
-		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
-	})
+	botNotifier := utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret)
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("router", func(count uint64, workStatusURL string) {
+		services.StopSspAdapterOrtbStreams(ctx, workStatusURL)
+	}, botNotifier, ctx)
 	redisWriteErrorMonitor.Start()
 
 	s := grpc.NewServer()

--- a/cmd/spp-adapter/main.go
+++ b/cmd/spp-adapter/main.go
@@ -98,9 +98,10 @@ func main() {
 	go s.StartAsync()
 	log.Println("⏰ Scheduler started (every 30 seconds)")
 
-	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("SSP adapter ORTB", func(count uint64) {
-		services.StopAllSspAdapterOrtbStreams(ctx, cfg.SspAdapterWorkStatusURLs)
-	})
+	botNotifier := utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret)
+	redisWriteErrorMonitor := services.NewRedisWriteErrorMonitor("SSP adapter ORTB", func(count uint64, workStatusURL string) {
+		services.StopSspAdapterOrtbStreams(ctx, workStatusURL)
+	}, botNotifier, ctx)
 	redisWriteErrorMonitor.Start()
 
 	router := chi.NewRouter()
@@ -126,6 +127,7 @@ func main() {
 		siteIdsAndDomains,
 		geoToLang,
 		redisWriteErrorMonitor,
+		cfg.SspAdapterWorkStatusURL,
 	)
 	log.Println("HTTP routes initialized")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,8 @@ type BiddingEngineConfig struct {
 	SspGeoDspPercentsMainstreamFilePath string   `yaml:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH" env:"SSP_GEO_DSP_PERCENTS_MAINSTREAM_FILE_PATH"`
 	AdmDomain                           string   `yaml:"ADM_DOMAIN" env:"ADM_DOMAIN"`
 	SspAdapterWorkStatusURLs            []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS" env-default:"server1.twinbidexchange.com:8050,server2.twinbidexchange.com:8050,server3.twinbidexchange.com:8050,server4.twinbidexchange.com:8050"`
+	BotBaseURL                          string   `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret                   string   `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 
 	RedisConfig
 }
@@ -152,6 +154,8 @@ type RouterConfig struct {
 	MaxParallelRequests      int      `yaml:"MAX_PARALLEL_REQUESTS" env:"MAX_PARALLEL_REQUESTS" env-default:"64"`
 	Debug                    bool     `yaml:"DEBUG" env:"DEBUG" env-default:"false"`
 	SspAdapterWorkStatusURLs []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS" env-default:"server1.twinbidexchange.com:8050,server2.twinbidexchange.com:8050,server3.twinbidexchange.com:8050,server4.twinbidexchange.com:8050"`
+	BotBaseURL               string   `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret        string   `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 
 	RedisConfig
 }
@@ -195,6 +199,9 @@ type SppAdapterConfig struct {
 	Domains23LevelPath       string   `yaml:"DOMAINS_23_LEVEL_PATH" env:"DOMAINS_23_LEVEL_PATH"`
 	GeoToLangPath            string   `yaml:"GEO_TO_LANG_PATH" env:"GEO_TO_LANG_PATH"`
 	SspAdapterWorkStatusURLs []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS" env-default:"server1.twinbidexchange.com:8050,server2.twinbidexchange.com:8050,server3.twinbidexchange.com:8050,server4.twinbidexchange.com:8050"`
+	SspAdapterWorkStatusURL  string   `yaml:"SSP_ADAPTER_WORK_STATUS_URL" env:"SSP_ADAPTER_WORK_STATUS_URL"`
+	BotBaseURL               string   `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret        string   `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 
 	RedisConfig
 }
@@ -208,6 +215,9 @@ type AdmAdapterConfig struct {
 	RsaFullChain             string        `yaml:"RSA_FULLCHAIN_PEM" env:"RSA_FULLCHAIN_PEM"`
 	RsaPrivKey               string        `yaml:"RSA_PRIVKEY_PEM" env:"RSA_PRIVKEY_PEM"`
 	SspAdapterWorkStatusURLs []string      `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS" env-default:"server1.twinbidexchange.com:8050,server2.twinbidexchange.com:8050,server3.twinbidexchange.com:8050,server4.twinbidexchange.com:8050"`
+	SspAdapterWorkStatusURL  string        `yaml:"SSP_ADAPTER_WORK_STATUS_URL" env:"SSP_ADAPTER_WORK_STATUS_URL"`
+	BotBaseURL               string        `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret        string        `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 
 	RedisConfig
 }
@@ -218,6 +228,8 @@ type KafkaLoaderConfig struct {
 	BatchRatioConfig
 	EmptyLoopPauseMS         int      `yaml:"EMPTY_LOOP_PAUSE_MS" env:"EMPTY_LOOP_PAUSE_MS" env-default:"200"`
 	SspAdapterWorkStatusURLs []string `yaml:"SSP_ADAPTER_WORK_STATUS_URLS" env:"SSP_ADAPTER_WORK_STATUS_URLS" env-default:"server1.twinbidexchange.com:8050,server2.twinbidexchange.com:8050,server3.twinbidexchange.com:8050,server4.twinbidexchange.com:8050"`
+	BotBaseURL               string   `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret        string   `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 }
 
 type ClickhouseConfig struct {
@@ -271,8 +283,10 @@ type ClickhouseLoaderConfig struct {
 	TimeoutSec     int `yaml:"TIMEOUT_SEC" env:"TIMEOUT_SEC"`
 	BatchTimeoutMS int `yaml:"CLICKHOUSE_BATCH_TIMEOUT_MS" env:"CLICKHOUSE_BATCH_TIMEOUT_MS" env-default:"800"`
 
-	ImpressionClickFlushIntervalSec int `yaml:"IMPRESSION_CLICK_FLUSH_INTERVAL_SEC" env:"IMPRESSION_CLICK_FLUSH_INTERVAL_SEC" env-default:"30"`
-	EmptyLoopPauseMS                int `yaml:"EMPTY_LOOP_PAUSE_MS" env:"EMPTY_LOOP_PAUSE_MS" env-default:"200"`
+	ImpressionClickFlushIntervalSec int    `yaml:"IMPRESSION_CLICK_FLUSH_INTERVAL_SEC" env:"IMPRESSION_CLICK_FLUSH_INTERVAL_SEC" env-default:"30"`
+	EmptyLoopPauseMS                int    `yaml:"EMPTY_LOOP_PAUSE_MS" env:"EMPTY_LOOP_PAUSE_MS" env-default:"200"`
+	BotBaseURL                      string `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret               string `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 }
 
 type MockDspConfig struct {

--- a/internal/services/bidEngine/web/v_2_5.go
+++ b/internal/services/bidEngine/web/v_2_5.go
@@ -127,26 +127,26 @@ func (s *Server) GetWinnerBid_V2_5(
 	for _, uuid := range admUUIDs {
 		if err := utils.WriteUUIDKeyToRedis(ctx, s.redisAdmClient, uuid, s.redisUUIDKeyTTL); err != nil {
 			log.Printf("failed to write ADM UUID key in GetWinnerBidInternal: %v", err)
-			s.redisWriteErrorMonitor.Record(err)
+			s.redisWriteErrorMonitor.RecordForURL(err, req.SspUrl)
 		}
 	}
 
 	for _, uuid := range nurlUUIDs {
 		if err := utils.WriteUUIDKeyToRedis(ctx, s.redisNurlClient, uuid, s.redisUUIDKeyTTL); err != nil {
 			log.Printf("failed to write NURL UUID key in GetWinnerBidInternal: %v", err)
-			s.redisWriteErrorMonitor.Record(err)
+			s.redisWriteErrorMonitor.RecordForURL(err, req.SspUrl)
 		}
 	}
 
 	for _, uuid := range req.ImpIdUuid {
 		if err := utils.WriteWinStats(ctx, s.redisClients, uuid, clickhouseBid[uuid], req.Logged); err != nil {
 			log.Printf("failed to WriteJsonToRedis Bid BID_RESPONSE_WINNER in GetWinnerBidInternal: %v", err)
-			s.redisWriteErrorMonitor.Record(err)
+			s.redisWriteErrorMonitor.RecordForURL(err, req.SspUrl)
 		}
 
 		if err := utils.AddUUIDToRedisSet(ctx, s.redisClients, s.redisSetOrtb, uuid, req.Logged); err != nil {
 			log.Printf("failed to add ORTB UUID to Redis set in GetWinnerBidInternal: %v", err)
-			s.redisWriteErrorMonitor.Record(err)
+			s.redisWriteErrorMonitor.RecordForURL(err, req.SspUrl)
 		}
 	}
 

--- a/internal/services/dspRouter/web/v_2_5.go
+++ b/internal/services/dspRouter/web/v_2_5.go
@@ -403,7 +403,7 @@ func (s *Server) GetBids_V2_5(
 	for _, uuid := range req.ImpIdUuid {
 		if err := writeBidResponsesToRedis(s.redisClients, uuid, clickResponses, req.Logged); err != nil {
 			log.Printf("failed to write bid responses to Redis: %v", err)
-			s.redisWriteErrorMonitor.Record(err)
+			s.redisWriteErrorMonitor.RecordForURL(err, req.SspUrl)
 		}
 	}
 

--- a/internal/services/orchestrator/web/v_2_5.go
+++ b/internal/services/orchestrator/web/v_2_5.go
@@ -68,6 +68,7 @@ func (s *Server) GetWinnerBid_V2_5(
 			Typic:      req.Typic,
 			Format:     req.Format,
 			ImpIdUuid:  req.ImpIdUuid,
+			SspUrl:     req.SspUrl,
 		},
 	)
 	if err != nil {
@@ -97,6 +98,7 @@ func (s *Server) GetWinnerBid_V2_5(
 			Typic:        req.Typic,
 			Format:       req.Format,
 			ImpIdUuid:    req.ImpIdUuid,
+			SspUrl:       req.SspUrl,
 		},
 	)
 	if err != nil {

--- a/internal/services/redis_error_monitor.go
+++ b/internal/services/redis_error_monitor.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	utils "gitlab.com/twinbid-exchange/RTB-exchange/internal/grpc/utils_grpc"
 )
 
 const (
@@ -21,16 +23,29 @@ const (
 type RedisWriteErrorMonitor struct {
 	name     string
 	errors   atomic.Uint64
-	stopFunc func(uint64)
+	lastURL  atomic.Value
+	stopFunc func(uint64, string)
+	notifier *utils.BotMessage
+	ctx      context.Context
 }
 
-func NewRedisWriteErrorMonitor(name string, stopFunc func(uint64)) *RedisWriteErrorMonitor {
-	return &RedisWriteErrorMonitor{name: name, stopFunc: stopFunc}
+func NewRedisWriteErrorMonitor(name string, stopFunc func(uint64, string), notifier *utils.BotMessage, ctx context.Context) *RedisWriteErrorMonitor {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &RedisWriteErrorMonitor{name: name, stopFunc: stopFunc, notifier: notifier, ctx: ctx}
 }
 
 func (m *RedisWriteErrorMonitor) Record(err error) {
+	m.RecordForURL(err, "")
+}
+
+func (m *RedisWriteErrorMonitor) RecordForURL(err error, workStatusURL string) {
 	if err == nil || m == nil {
 		return
+	}
+	if strings.TrimSpace(workStatusURL) != "" {
+		m.lastURL.Store(workStatusURL)
 	}
 	m.errors.Add(1)
 }
@@ -47,15 +62,25 @@ func (m *RedisWriteErrorMonitor) Start() {
 		for range ticker.C {
 			count := m.errors.Swap(0)
 			if count >= RedisWriteErrorStopThresholdPerSec {
-				log.Printf("❌ %s Redis write errors reached %d requests/sec, stopping all SSP adapter ORTB streams", m.name, count)
+				workStatusURL, _ := m.lastURL.Load().(string)
+				message := fmt.Sprintf("❌ service=%s Redis write errors reached %d requests/sec, stopping SSP adapter ORTB streams; ssp_adapter_url=%s", m.name, count, workStatusURL)
+				log.Print(message)
+				if err := m.notifier.SendTextMessageToBot(m.ctx, message); err != nil {
+					log.Printf("❌ failed to send bot notification: %v", err)
+				}
 				if m.stopFunc != nil {
-					m.stopFunc(count)
+					m.stopFunc(count, workStatusURL)
 				}
 				continue
 			}
 
 			if count >= RedisWriteErrorLogThresholdPerSec {
-				log.Printf("❌ %s Redis write errors reached %d requests/sec", m.name, count)
+				workStatusURL, _ := m.lastURL.Load().(string)
+				message := fmt.Sprintf("❌ service=%s Redis write errors reached %d requests/sec; ssp_adapter_url=%s", m.name, count, workStatusURL)
+				log.Print(message)
+				if err := m.notifier.SendTextMessageToBot(m.ctx, message); err != nil {
+					log.Printf("❌ failed to send bot notification: %v", err)
+				}
 			}
 		}
 	}()

--- a/internal/services/sspAdapter/web/common.go
+++ b/internal/services/sspAdapter/web/common.go
@@ -21,6 +21,7 @@ func getAdm(
 	redisAdmClient *redis.Client,
 	redisSetClicks string,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
 	format, ok := constants.CodeToFormat[input.Format]
@@ -40,7 +41,7 @@ func getAdm(
 	exists, err := utils.UUIDKeyExistsInRedis(ctx, redisAdmClient, input.GlobalId)
 	if err != nil {
 		log.Printf("failed to check ADM UUID key %s in url %s in getAdm: %v", input.GlobalId, r.URL.String(), err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -52,10 +53,10 @@ func getAdm(
 
 	if err := utils.WriteClickStats(ctx, redisClients, input.GlobalId, format, true); err != nil {
 		log.Printf("failed to WriteClickStats in getAdm: %v", err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetClicks, input.GlobalId, true); err != nil {
 		log.Printf("failed to add click UUID to Redis set in getAdm: %v", err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 	}
 
 	http.Redirect(w, r, decodedURL, http.StatusFound)
@@ -69,6 +70,7 @@ func getNurl(
 	redisNurlClient *redis.Client,
 	redisSetImpressions string,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
 ) {
 	input := r.Context().Value(httpin.Input).(*admNurlRequest)
 	format, ok := constants.CodeToFormat[input.Format]
@@ -88,7 +90,7 @@ func getNurl(
 	exists, err := utils.UUIDKeyExistsInRedis(ctx, redisNurlClient, input.GlobalId)
 	if err != nil {
 		log.Printf("failed to check NURL UUID key %s in url %s in getNurl: %v", input.GlobalId, r.URL.String(), err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -100,10 +102,10 @@ func getNurl(
 
 	if err := utils.WriteImpressionStats(ctx, redisClients, input.GlobalId, format, true); err != nil {
 		log.Printf("failed to WriteImpressionStats in getNurl: %v", err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 	} else if err := utils.AddUUIDToRedisSet(ctx, redisClients, redisSetImpressions, input.GlobalId, true); err != nil {
 		log.Printf("failed to add impression UUID to Redis set in getNurl: %v", err)
-		redisWriteErrorMonitor.Record(err)
+		redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 	}
 
 	http.Redirect(w, r, decodedURL, http.StatusFound)

--- a/internal/services/sspAdapter/web/route.go
+++ b/internal/services/sspAdapter/web/route.go
@@ -110,6 +110,7 @@ func InitHttpRoutes(
 	siteIdsAndDomains *utils.SiteIdsAndDomains,
 	geoToLang geoBadIp.GeoToLang,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
 ) {
 	var counter uint64 = 0
 	integration.UseGochiURLParam("path", chi.URLParam)
@@ -117,13 +118,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
@@ -183,13 +184,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	//---------------------------------------------------------------
@@ -197,13 +198,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	//---------------------------------------------------------------
@@ -211,13 +212,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatMc, &counter, MAINSTREAM, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatMc, &counter, MAINSTREAM, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 }
 
@@ -233,18 +234,19 @@ func InitHttpsRoutes(
 	admTimeout,
 	nurlTimeout time.Duration,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
 ) {
 	integration.UseGochiURLParam("path", chi.URLParam)
 
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
 	).Get(GetAdmUrl, func(w http.ResponseWriter, r *http.Request) {
-		getAdm(ctx, w, r, redisClientsClicks, redisAdmClient, redisSetClicks, redisWriteErrorMonitor)
+		getAdm(ctx, w, r, redisClientsClicks, redisAdmClient, redisSetClicks, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
 	).Get(GetNurlUrl, func(w http.ResponseWriter, r *http.Request) {
-		getNurl(ctx, w, r, redisClientsImp, redisNurlClient, redisSetImpressions, redisWriteErrorMonitor)
+		getNurl(ctx, w, r, redisClientsImp, redisNurlClient, redisSetImpressions, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
 }

--- a/internal/services/sspAdapter/web/v_2_5.go
+++ b/internal/services/sspAdapter/web/v_2_5.go
@@ -44,6 +44,7 @@ func postBid_V2_5(
 	siteIdsAndDomains *utils.SiteIdsAndDomains,
 	geoToLang geoBadIp.GeoToLang,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
 ) {
 	var input *postBidRequest_V2_5
 	defer func() {
@@ -261,7 +262,7 @@ func postBid_V2_5(
 			float64(input.Payload.Imp[i].GetBidfloor()),
 		); err != nil {
 			log.Printf("failed to WriteStats in postBid_V2_5: %v", err)
-			redisWriteErrorMonitor.Record(err)
+			redisWriteErrorMonitor.RecordForURL(err, sspAdapterWorkStatusURL)
 		}
 	}
 
@@ -277,6 +278,7 @@ func postBid_V2_5(
 			Typic:      typic,
 			Format:     format,
 			ImpIdUuid:  impIdUuid,
+			SspUrl:     sspAdapterWorkStatusURL,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Improve observability and automated alerting for high Redis write error rates by sending notifications to an internal bot and including the SSP adapter work-status URL context when stopping streams. 
- Ensure the SSP adapter work-status endpoint is propagated through HTTP/GRPC call paths so the error monitor can stop the correct instance. 

### Description
- Extended `RedisWriteErrorMonitor` to store last observed SSP URL, accept a `BotMessage` notifier and `context.Context`, and send text notifications when thresholds are reached or logged. 
- Changed monitor API to `NewRedisWriteErrorMonitor(name, stopFunc(count, workStatusURL), notifier, ctx)` and added `RecordForURL(err, workStatusURL)` (keeps old `Record` behavior delegating to the new method). 
- Propagated `sspAdapterWorkStatusURL` through SSP adapter HTTP route handlers and GRPC requests by adding `SspUrl` fields where needed and passing the URL into calls so the monitor knows which SSP endpoint to target. 
- Updated multiple `cmd/*/main.go` entrypoints to create `BotMessage` via `utils.NewBotMessage(cfg.BotBaseURL, cfg.BotInternalSecret)`, pass it to the monitor, and send immediate bot notifications from Kafka/ClickHouse loader error handlers. 
- Added configuration keys for `BOT_BASE_URL` and `BOT_INTERNAL_SECRET` and introduced single `SSP_ADAPTER_WORK_STATUS_URL` fields (in places where a single URL is needed) while keeping existing list fields unchanged. 

### Testing
- Built the modified services with `go build ./cmd/...` for the changed binaries and ran `go test ./...` across the repository; the builds and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed377f3e8832888e5a4149d3d28f5)