### PR TITLE
Add ClickHouse-backed IP limit store and enforce IP limits in SSP adapter

### DIFF
--- a/cmd/spp-adapter/main.go
+++ b/cmd/spp-adapter/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
+	"net"
 	"os"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-co-op/gocron"
 	"gitlab.com/twinbid-exchange/RTB-exchange/internal/config"
@@ -88,6 +91,39 @@ func main() {
 		log.Fatalf("failed to NewGeoToLang: %v", err)
 	}
 
+	addr := net.JoinHostPort(cfg.ClickhouseConfig.Host, cfg.ClickhouseConfig.Port)
+	clickhouseConn, err := clickhouse.Open(&clickhouse.Options{
+		Addr:     []string{addr},
+		Protocol: clickhouse.Native,
+		TLS:      &tls.Config{},
+		Auth: clickhouse.Auth{
+			Username: cfg.ClickhouseConfig.Username,
+			Password: cfg.ClickhouseConfig.Password,
+			Database: cfg.ClickhouseConfig.Database,
+		},
+	})
+	if err != nil {
+		log.Fatalf("❌ ClickHouse Open connection failed: %v", err)
+	}
+	defer clickhouseConn.Close()
+
+	if err := clickhouseConn.Ping(ctx); err != nil {
+		log.Fatalf("❌ ClickHouse ping failed: %v", err)
+	}
+	log.Println("✅ Connected to ClickHouse for IP limits")
+
+	ipLimitStore := sppAdapterWeb.NewIPLimitStore()
+	if err := ipLimitStore.StartClickHouseLoaders(ctx, clickhouseConn, sppAdapterWeb.IPLimitConfig{
+		FullReloadInterval: time.Duration(cfg.IPLimitFullReloadMinutes) * time.Minute,
+		BatchLoadInterval:  time.Duration(cfg.IPLimitLatestBatchIntervalSec) * time.Second,
+		Tables: sppAdapterWeb.IPLimitTables{
+			IPv4: cfg.IPLimitIPv4Table,
+			IPv6: cfg.IPLimitIPv6Table,
+		},
+	}); err != nil {
+		log.Fatalf("failed to start IP limit ClickHouse loaders: %v", err)
+	}
+
 	s := gocron.NewScheduler(time.UTC)
 	s.Every(30).Seconds().Do(func() {
 		if err := siteIdsAndDomains.WriteSiteIdDomainToTheFile(); err != nil {
@@ -128,6 +164,7 @@ func main() {
 		geoToLang,
 		redisWriteErrorMonitor,
 		cfg.SspAdapterWorkStatusURL,
+		ipLimitStore,
 	)
 	log.Println("HTTP routes initialized")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,7 +169,8 @@ type OrchestratorConfig struct {
 }
 
 type SppAdapterConfig struct {
-	HttpServer          HttpServer
+	HttpServer HttpServer
+	ClickhouseConfig
 	UriOfOrchestrator   string        `yaml:"URI_OF_ORCHESTRATOR" env:"URI_OF_ORCHESTRATOR"`
 	AdmTimeout          time.Duration `yaml:"ADM_TIMEOUT" env:"ADM_TIMEOUT"`
 	NurlTimeout         time.Duration `yaml:"NURL_TIMEOUT" env:"NURL_TIMEOUT"`
@@ -192,13 +193,17 @@ type SppAdapterConfig struct {
 	SspIppAdlFeeds MapStringToString `yaml:"SSP_IPP_ADL_FEEDS" env:"SSP_IPP_ADL_FEEDS"`
 	SspIppMcFeeds  MapStringToString `yaml:"SSP_IPP_MC_FEEDS" env:"SSP_IPP_MC_FEEDS"`
 
-	SiteIdDomainPath        string `yaml:"SITE_ID_DOMAIN_PATH" env:"SITE_ID_DOMAIN_PATH"`
-	Domains1LevelPath       string `yaml:"DOMAINS_1_LEVEL_PATH" env:"DOMAINS_1_LEVEL_PATH"`
-	Domains23LevelPath      string `yaml:"DOMAINS_23_LEVEL_PATH" env:"DOMAINS_23_LEVEL_PATH"`
-	GeoToLangPath           string `yaml:"GEO_TO_LANG_PATH" env:"GEO_TO_LANG_PATH"`
-	SspAdapterWorkStatusURL string `yaml:"SSP_ADAPTER_WORK_STATUS_URL" env:"SSP_ADAPTER_WORK_STATUS_URL"`
-	BotBaseURL              string `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
-	BotInternalSecret       string `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
+	SiteIdDomainPath              string `yaml:"SITE_ID_DOMAIN_PATH" env:"SITE_ID_DOMAIN_PATH"`
+	Domains1LevelPath             string `yaml:"DOMAINS_1_LEVEL_PATH" env:"DOMAINS_1_LEVEL_PATH"`
+	Domains23LevelPath            string `yaml:"DOMAINS_23_LEVEL_PATH" env:"DOMAINS_23_LEVEL_PATH"`
+	GeoToLangPath                 string `yaml:"GEO_TO_LANG_PATH" env:"GEO_TO_LANG_PATH"`
+	SspAdapterWorkStatusURL       string `yaml:"SSP_ADAPTER_WORK_STATUS_URL" env:"SSP_ADAPTER_WORK_STATUS_URL"`
+	IPLimitFullReloadMinutes      int    `yaml:"IP_LIMIT_FULL_RELOAD_MINUTES" env:"IP_LIMIT_FULL_RELOAD_MINUTES" env-default:"60"`
+	IPLimitLatestBatchIntervalSec int    `yaml:"IP_LIMIT_LATEST_BATCH_INTERVAL_SEC" env:"IP_LIMIT_LATEST_BATCH_INTERVAL_SEC" env-default:"60"`
+	IPLimitIPv4Table              string `yaml:"IP_LIMIT_IPV4_TABLE" env:"IP_LIMIT_IPV4_TABLE" env-default:"ip_limit_ipv4"`
+	IPLimitIPv6Table              string `yaml:"IP_LIMIT_IPV6_TABLE" env:"IP_LIMIT_IPV6_TABLE" env-default:"ip_limit_ipv6"`
+	BotBaseURL                    string `yaml:"BOT_BASE_URL" env:"BOT_BASE_URL"`
+	BotInternalSecret             string `yaml:"BOT_INTERNAL_SECRET" env:"BOT_INTERNAL_SECRET"`
 
 	RedisConfig
 }

--- a/internal/services/sspAdapter/web/ip_limit.go
+++ b/internal/services/sspAdapter/web/ip_limit.go
@@ -1,0 +1,209 @@
+package sppAdapterWeb
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+type IPLimitMap map[string]struct{}
+
+type IPLimitTables struct {
+	IPv4 string
+	IPv6 string
+}
+
+type IPLimitConfig struct {
+	FullReloadInterval time.Duration
+	BatchLoadInterval  time.Duration
+	Tables             IPLimitTables
+}
+
+type IPLimitStore struct {
+	ipv4 atomic.Value
+	ipv6 atomic.Value
+
+	mu              sync.Mutex
+	lastIPv4BatchAt time.Time
+	lastIPv6BatchAt time.Time
+}
+
+func NewIPLimitStore() *IPLimitStore {
+	s := &IPLimitStore{}
+	s.ipv4.Store(IPLimitMap{})
+	s.ipv6.Store(IPLimitMap{})
+	return s
+}
+
+func (s *IPLimitStore) ContainsIPv4(ip string) bool { return s.contains(&s.ipv4, ip) }
+func (s *IPLimitStore) ContainsIPv6(ip string) bool { return s.contains(&s.ipv6, ip) }
+
+func (s *IPLimitStore) contains(value *atomic.Value, ip string) bool {
+	if s == nil || strings.TrimSpace(ip) == "" {
+		return false
+	}
+	items, ok := value.Load().(IPLimitMap)
+	if !ok {
+		return false
+	}
+	_, exists := items[ip]
+	return exists
+}
+
+func (s *IPLimitStore) StartClickHouseLoaders(ctx context.Context, ch clickhouse.Conn, cfg IPLimitConfig) error {
+	if err := s.ReloadAll(ctx, ch, cfg.Tables); err != nil {
+		return fmt.Errorf("load initial IP limit maps: %w", err)
+	}
+
+	go s.fullReloadLoop(ctx, ch, cfg)
+	go s.latestBatchLoop(ctx, ch, cfg)
+
+	return nil
+}
+
+func (s *IPLimitStore) fullReloadLoop(ctx context.Context, ch clickhouse.Conn, cfg IPLimitConfig) {
+	ticker := time.NewTicker(cfg.FullReloadInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.ReloadAll(ctx, ch, cfg.Tables); err != nil {
+				log.Printf("failed to reload full IP limit maps: %v", err)
+			}
+		}
+	}
+}
+
+func (s *IPLimitStore) latestBatchLoop(ctx context.Context, ch clickhouse.Conn, cfg IPLimitConfig) {
+	ticker := time.NewTicker(cfg.BatchLoadInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.LoadNewBatches(ctx, ch, cfg.Tables); err != nil {
+				log.Printf("failed to load new IP limit batches: %v", err)
+			}
+		}
+	}
+}
+
+func (s *IPLimitStore) ReloadAll(ctx context.Context, ch clickhouse.Conn, tables IPLimitTables) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ipv4, lastIPv4BatchAt, err := fetchIPLimitAll(ctx, ch, tables.IPv4)
+	if err != nil {
+		return fmt.Errorf("load all ipv4 limits: %w", err)
+	}
+	ipv6, lastIPv6BatchAt, err := fetchIPLimitAll(ctx, ch, tables.IPv6)
+	if err != nil {
+		return fmt.Errorf("load all ipv6 limits: %w", err)
+	}
+
+	s.ipv4.Store(ipv4)
+	s.ipv6.Store(ipv6)
+	s.lastIPv4BatchAt = lastIPv4BatchAt
+	s.lastIPv6BatchAt = lastIPv6BatchAt
+
+	log.Printf("loaded IP limit maps: ipv4=%d last_ipv4_batch_at=%s ipv6=%d last_ipv6_batch_at=%s", len(ipv4), lastIPv4BatchAt.Format(time.RFC3339Nano), len(ipv6), lastIPv6BatchAt.Format(time.RFC3339Nano))
+	return nil
+}
+
+func (s *IPLimitStore) LoadNewBatches(ctx context.Context, ch clickhouse.Conn, tables IPLimitTables) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ipv4, lastIPv4BatchAt, err := fetchIPLimitAfter(ctx, ch, tables.IPv4, s.lastIPv4BatchAt)
+	if err != nil {
+		return fmt.Errorf("load new ipv4 limits: %w", err)
+	}
+	ipv6, lastIPv6BatchAt, err := fetchIPLimitAfter(ctx, ch, tables.IPv6, s.lastIPv6BatchAt)
+	if err != nil {
+		return fmt.Errorf("load new ipv6 limits: %w", err)
+	}
+
+	s.merge(&s.ipv4, ipv4)
+	s.merge(&s.ipv6, ipv6)
+	if lastIPv4BatchAt.After(s.lastIPv4BatchAt) {
+		s.lastIPv4BatchAt = lastIPv4BatchAt
+	}
+	if lastIPv6BatchAt.After(s.lastIPv6BatchAt) {
+		s.lastIPv6BatchAt = lastIPv6BatchAt
+	}
+
+	log.Printf("loaded new IP limit batches: ipv4=%d last_ipv4_batch_at=%s ipv6=%d last_ipv6_batch_at=%s", len(ipv4), s.lastIPv4BatchAt.Format(time.RFC3339Nano), len(ipv6), s.lastIPv6BatchAt.Format(time.RFC3339Nano))
+	return nil
+}
+
+func (s *IPLimitStore) merge(value *atomic.Value, batch IPLimitMap) {
+	if len(batch) == 0 {
+		return
+	}
+	current, _ := value.Load().(IPLimitMap)
+	next := make(IPLimitMap, len(current)+len(batch))
+	for ip := range current {
+		next[ip] = struct{}{}
+	}
+	for ip := range batch {
+		next[ip] = struct{}{}
+	}
+	value.Store(next)
+}
+
+func fetchIPLimitAll(ctx context.Context, ch clickhouse.Conn, table string) (IPLimitMap, time.Time, error) {
+	return fetchIPLimitRows(ctx, ch, fmt.Sprintf("SELECT ip, created_at FROM %s", clickhouseIdentifier(table)))
+}
+
+func fetchIPLimitAfter(ctx context.Context, ch clickhouse.Conn, table string, after time.Time) (IPLimitMap, time.Time, error) {
+	return fetchIPLimitRows(ctx, ch, fmt.Sprintf("SELECT ip, created_at FROM %s WHERE created_at > ?", clickhouseIdentifier(table)), after)
+}
+
+func fetchIPLimitRows(ctx context.Context, ch clickhouse.Conn, query string, args ...any) (IPLimitMap, time.Time, error) {
+	rows, err := ch.Query(ctx, query, args...)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	defer rows.Close()
+
+	result := make(IPLimitMap)
+	var maxCreatedAt time.Time
+	for rows.Next() {
+		var (
+			ip        string
+			createdAt time.Time
+		)
+		if err := rows.Scan(&ip, &createdAt); err != nil {
+			return nil, time.Time{}, err
+		}
+		if ip = strings.TrimSpace(ip); ip != "" {
+			result[ip] = struct{}{}
+		}
+		if createdAt.After(maxCreatedAt) {
+			maxCreatedAt = createdAt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, time.Time{}, err
+	}
+	return result, maxCreatedAt, nil
+}
+
+func clickhouseIdentifier(identifier string) string {
+	parts := strings.Split(identifier, ".")
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ReplaceAll(strings.TrimSpace(part), "`", "``")
+		quoted = append(quoted, "`"+part+"`")
+	}
+	return strings.Join(quoted, ".")
+}

--- a/internal/services/sspAdapter/web/route.go
+++ b/internal/services/sspAdapter/web/route.go
@@ -111,6 +111,7 @@ func InitHttpRoutes(
 	geoToLang geoBadIp.GeoToLang,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 	sspAdapterWorkStatusURL string,
+	ipLimitStore *IPLimitStore,
 ) {
 	var counter uint64 = 0
 	integration.UseGochiURLParam("path", chi.URLParam)
@@ -118,13 +119,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopAdl, &counter, ADULT, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_POP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsPopMc, &counter, MAINSTREAM, constants.POP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	httpRouter.With(
@@ -184,13 +185,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppAdl, &counter, ADULT, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_IPP_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsIppMc, &counter, MAINSTREAM, constants.IPP, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	//---------------------------------------------------------------
@@ -198,13 +199,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanAdl, &counter, ADULT, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_BAN_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsBanMc, &counter, MAINSTREAM, constants.BAN, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	//---------------------------------------------------------------
@@ -212,13 +213,13 @@ func InitHttpRoutes(
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_ADL_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatAdl, &counter, ADULT, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 
 	httpRouter.With(
 		httpin.NewInput(postBidRequest_V2_5{}),
 	).Post(PostBid_NAT_MC_V_2_5_URL, func(w http.ResponseWriter, r *http.Request) {
-		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatMc, &counter, MAINSTREAM, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
+		postBid_V2_5(ctx, w, r, redisClients, isBadIp, getCountryISO, orchestratorClient, bidRequestTimeout, sspFeedsNatMc, &counter, MAINSTREAM, constants.NAT, siteIdsAndDomains, geoToLang, redisWriteErrorMonitor, sspAdapterWorkStatusURL, ipLimitStore)
 	})
 }
 

--- a/internal/services/sspAdapter/web/v_2_5.go
+++ b/internal/services/sspAdapter/web/v_2_5.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/ggicci/httpin"
@@ -45,6 +46,7 @@ func postBid_V2_5(
 	geoToLang geoBadIp.GeoToLang,
 	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
 	sspAdapterWorkStatusURL string,
+	ipLimitStore *IPLimitStore,
 ) {
 	var input *postBidRequest_V2_5
 	defer func() {
@@ -98,6 +100,30 @@ func postBid_V2_5(
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 
+	}
+
+	if device.Ip != nil {
+		ip := strings.TrimSpace(device.GetIp())
+		device.Ip = &ip
+	}
+	if device.Ipv6 != nil {
+		ipv6 := strings.TrimSpace(device.GetIpv6())
+		device.Ipv6 = &ipv6
+	}
+
+	if ipLimitStore != nil {
+		if ip := device.GetIp(); ip != "" && ipLimitStore.ContainsIPv4(ip) {
+			err := fmt.Errorf("Ip is limited: %s", ip)
+			log.Printf("error: %s, feed: %s", err.Error(), ssp_domain)
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		if ip := device.GetIpv6(); ip != "" && ipLimitStore.ContainsIPv6(ip) {
+			err := fmt.Errorf("Ipv6 is limited: %s", ip)
+			log.Printf("error: %s, feed: %s", err.Error(), ssp_domain)
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 	}
 
 	if device.Ua == nil {


### PR DESCRIPTION
### Motivation
- Introduce a centralized, ClickHouse-backed IP ban/limit mechanism to block requests from known IPs at the SSP adapter ingress.
- Provide periodic full reloads and incremental batch updates to keep the in-memory IP lists current without restarting the service.
- Pass the IP limit store into request handlers so incoming bid requests can be rejected early for limited IPs.

### Description
- Add `internal/services/sspAdapter/web/ip_limit.go` implementing `IPLimitStore` with full reload and incremental batch loaders from ClickHouse and thread-safe in-memory maps (`IPLimitMap`), plus helper query and identifier quoting functions.
- Wire ClickHouse connection setup into `cmd/spp-adapter/main.go` using `clickhouse-go/v2` and start the `IPLimitStore` loaders with intervals configurable via config values, and pass the store into HTTP route initialization.
- Extend `internal/config/config.go` to include `ClickhouseConfig` and IP limit configuration fields (`IPLimitFullReloadMinutes`, `IPLimitLatestBatchIntervalSec`, `IPLimitIPv4Table`, `IPLimitIPv6Table`) in `SppAdapterConfig`.
- Propagate the `ipLimitStore` parameter through `InitHttpRoutes` and into `postBid_V2_5` handler, trim incoming IP strings, and enforce IP checks to return `403 Forbidden` for limited IPv4/IPv6 addresses.
- Small imports and logging additions to indicate ClickHouse connectivity and error handling on loader startup.

### Testing
- Built the adapter binary with `go build ./cmd/spp-adapter` and the build completed successfully.
- Ran unit and package tests with `go test ./...` and they passed for the modified packages.
- Manual sanity run verified ClickHouse connection sequence and that the IP loader goroutines start without error in the service logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329a8935788328b9e2691d9db97242)