### PR TITLE
Split ADM/NURL routes (NURL on HTTP:80) and add WrapNurlURL helper

### DIFF
--- a/cmd/adm-adapter/main.go
+++ b/cmd/adm-adapter/main.go
@@ -110,10 +110,10 @@ func main() {
 	)
 	redisWriteErrorMonitor.Start()
 
-	router := httpServer.InitHttpRouter(chi.NewRouter())
+	admRouter := httpServer.InitHttpRouter(chi.NewRouter())
 	sppAdapterWeb.InitHttpsRoutes(
 		ctx,
-		router,
+		admRouter,
 		redisClients.Impressions,
 		redisClients.Clicks,
 		redisAdmClient,
@@ -125,7 +125,21 @@ func main() {
 		redisWriteErrorMonitor,
 		cfg.SspAdapterWorkStatusURL,
 	)
-	log.Println("HTTP routes initialized")
+	log.Println("ADM HTTPS routes initialized")
 
-	httpServer.RunHttpsServerOptimized(ctx, router, cfg.HttpServer.Host, cfg.HttpServer.Port, cfg.FullChain, cfg.PrivKey, cfg.RsaFullChain, cfg.RsaPrivKey)
+	nurlRouter := httpServer.InitHttpRouter(chi.NewRouter())
+	sppAdapterWeb.InitNurlRoutes(
+		ctx,
+		nurlRouter,
+		redisClients.Impressions,
+		redisNurlClient,
+		cfg.RedisSetImpressions,
+		cfg.NurlTimeout,
+		redisWriteErrorMonitor,
+		cfg.SspAdapterWorkStatusURL,
+	)
+	log.Println("NURL HTTP routes initialized")
+
+	go httpServer.RunHttpServer(ctx, nurlRouter, cfg.HttpServer.Host, 80)
+	httpServer.RunHttpsServerOptimized(ctx, admRouter, cfg.HttpServer.Host, cfg.HttpServer.Port, cfg.FullChain, cfg.PrivKey, cfg.RsaFullChain, cfg.RsaPrivKey)
 }

--- a/internal/grpc/utils_grpc/urls.go
+++ b/internal/grpc/utils_grpc/urls.go
@@ -12,8 +12,14 @@ const (
 	ADM  = "adm"
 )
 
-func WrapURL(hostname, originalURL, globalId, admOrnurlOrBurl, format string) string {
+func WrapURL(hostname, originalURL, globalId, format string) string {
 	encodeUrl := url.QueryEscape(originalURL)
-	return fmt.Sprintf("https://%s/%s?id=%s&url=%s&f=%s",
-		hostname, admOrnurlOrBurl, globalId, encodeUrl, constants.FormatToCodes[format])
+	return fmt.Sprintf("https://%s/adm?id=%s&url=%s&f=%s",
+		hostname, globalId, encodeUrl, constants.FormatToCodes[format])
+}
+
+func WrapNurlURL(hostname, originalURL, globalId, format string) string {
+	encodeUrl := url.QueryEscape(originalURL)
+	return fmt.Sprintf("http://%s:80/nurl?id=%s&url=%s&f=%s",
+		hostname, globalId, encodeUrl, constants.FormatToCodes[format])
 }

--- a/internal/services/bidEngine/service/v_2_5.go
+++ b/internal/services/bidEngine/service/v_2_5.go
@@ -160,10 +160,10 @@ func GetWinnerBidInternal_V_2_5(
 
 		var finalBid *ortb_V2_5.Bid
 
-		wrappedNurl := utils.WrapURL(admDomain, winner.bid.GetNurl(), ImpIdUuid[impID], utils.NURL, req.Format)
+		wrappedNurl := utils.WrapNurlURL(admDomain, winner.bid.GetNurl(), ImpIdUuid[impID], req.Format)
 
 		if logged {
-			wrappedAdm := utils.WrapURL(admDomain, winner.bid.GetAdm(), ImpIdUuid[impID], utils.ADM, req.Format)
+			wrappedAdm := utils.WrapURL(admDomain, winner.bid.GetAdm(), ImpIdUuid[impID], req.Format)
 			finalBid = &ortb_V2_5.Bid{
 				Id:    winner.bid.Id,
 				Impid: winner.bid.Impid,

--- a/internal/services/sspAdapter/web/route.go
+++ b/internal/services/sspAdapter/web/route.go
@@ -240,15 +240,28 @@ func InitHttpsRoutes(
 ) {
 	integration.UseGochiURLParam("path", chi.URLParam)
 
-	var nurlClient = &http.Client{
-		Timeout: 3 * time.Second,
-	}
-
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
 	).Get(GetAdmUrl, func(w http.ResponseWriter, r *http.Request) {
 		getAdm(ctx, w, r, redisClientsClicks, redisAdmClient, redisSetClicks, redisWriteErrorMonitor, sspAdapterWorkStatusURL)
 	})
+}
+
+func InitNurlRoutes(
+	ctx context.Context,
+	httpRouter *chi.Mux,
+	redisClientsImp []*redis.Client,
+	redisNurlClient *redis.Client,
+	redisSetImpressions string,
+	nurlTimeout time.Duration,
+	redisWriteErrorMonitor *services.RedisWriteErrorMonitor,
+	sspAdapterWorkStatusURL string,
+) {
+	integration.UseGochiURLParam("path", chi.URLParam)
+
+	var nurlClient = &http.Client{
+		Timeout: 3 * time.Second,
+	}
 
 	httpRouter.With(
 		httpin.NewInput(admNurlRequest{}),
@@ -256,5 +269,3 @@ func InitHttpsRoutes(
 		getNurl(ctx, w, r, redisClientsImp, redisNurlClient, redisSetImpressions, redisWriteErrorMonitor, sspAdapterWorkStatusURL, nurlClient)
 	})
 }
-
-


### PR DESCRIPTION
### Motivation

- Separate handling of ADM and NURL endpoints so NURL callbacks can be served over plain HTTP on port 80 while ADM remains on HTTPS.

### Description

- Refactored route initialization in `cmd/adm-adapter/main.go` to create separate `admRouter` and `nurlRouter`, start an HTTP server on port 80 for NURL routes, and run the ADM routes on the optimized HTTPS server.  
- Added `WrapNurlURL` in `internal/grpc/utils_grpc/urls.go` and simplified `WrapURL` to always produce an ADM HTTPS URL; `WrapNurlURL` generates an explicit `http://hostname:80/nurl` URL.  
- Updated the bid engine in `internal/services/bidEngine/service/v_2_5.go` to use `WrapNurlURL` for NURL values and to keep ADM wrapping via `WrapURL`.  
- Split the SSP adapter web routes in `internal/services/sspAdapter/web/route.go` into `InitHttpsRoutes` (ADM) and `InitNurlRoutes` (NURL) and moved the NURL-specific HTTP client into the new NURL initializer.

### Testing

- Built the application (`go build`) and ran unit tests with `go test ./...`, which completed successfully.  
- Verified basic route startup by launching the service locally and confirming both HTTP (port 80) and HTTPS listeners started without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439f0a706483288908dc82354df432)