### PR TITLE
Add bloom filter indexes for input UUID columns (impressions_in, clicks_in)

### DIFF
--- a/internal/services/clickhouse-loader/createDb.go
+++ b/internal/services/clickhouse-loader/createDb.go
@@ -163,7 +163,9 @@ CREATE TABLE IF NOT EXISTS {db}.impressions_in
     ad_format                 LowCardinality(String) DEFAULT '',
 
     uuid UUID,
-    impressions_uuid UUID
+    impressions_uuid UUID,
+
+    INDEX idx_impressions_in_impressions_uuid impressions_uuid TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = MergeTree
 ORDER BY (event_time_impressions, uuid)
@@ -178,11 +180,19 @@ CREATE TABLE IF NOT EXISTS {db}.clicks_in
     ad_format            LowCardinality(String) DEFAULT '',
 
     uuid UUID,
-    clicks_uuid UUID
+    clicks_uuid UUID,
+
+    INDEX idx_clicks_in_clicks_uuid clicks_uuid TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = MergeTree
 ORDER BY (event_time_clicks, uuid)
 TTL created_at + INTERVAL 1 HOUR DELETE;
+
+ALTER TABLE {db}.impressions_in
+    ADD INDEX IF NOT EXISTS idx_impressions_in_impressions_uuid impressions_uuid TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE {db}.clicks_in
+    ADD INDEX IF NOT EXISTS idx_clicks_in_clicks_uuid clicks_uuid TYPE bloom_filter(0.01) GRANULARITY 1;
 
 
 -- ============================================================


### PR DESCRIPTION
### Motivation
- Improve ClickHouse lookup performance for the new `impressions_uuid` and `clicks_uuid` columns used by input pipelines and materialized view presence checks. 
- Ensure indexes are applied to both newly created and existing tables during startup DDL execution by making index creation idempotent.

### Description
- Added `INDEX idx_impressions_in_impressions_uuid impressions_uuid TYPE bloom_filter(0.01) GRANULARITY 1` to the `CREATE TABLE {db}.impressions_in` DDL in `internal/services/clickhouse-loader/createDb.go`.
- Added `INDEX idx_clicks_in_clicks_uuid clicks_uuid TYPE bloom_filter(0.01) GRANULARITY 1` to the `CREATE TABLE {db}.clicks_in` DDL in `internal/services/clickhouse-loader/createDb.go`.
- Added idempotent `ALTER TABLE {db}.impressions_in ADD INDEX IF NOT EXISTS ...` and `ALTER TABLE {db}.clicks_in ADD INDEX IF NOT EXISTS ...` statements so existing deployments receive the new indexes when running the DDL.

### Testing
- Ran `go test ./internal/services/clickhouse-loader`, which completed (package contains no test files).
- Started `go test ./...`, which was run but did not finish promptly and was stopped, so a full repository-wide test run was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e03000f483288a125afb7749c12d)