### PR TITLE
Add impressions_uuid/clicks_uuid UUIDs and bloom_filter indexes; make schema changes idempotent

### DIFF
--- a/internal/services/clickhouse-loader/createDb.go
+++ b/internal/services/clickhouse-loader/createDb.go
@@ -163,7 +163,9 @@ CREATE TABLE IF NOT EXISTS {db}.impressions_in
     ad_format                 LowCardinality(String) DEFAULT '',
 
     uuid UUID,
-    impressions_uuid UUID
+    impressions_uuid UUID,
+
+    INDEX idx_impressions_in_impressions_uuid impressions_uuid TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = MergeTree
 ORDER BY (event_time_impressions, uuid)
@@ -178,11 +180,25 @@ CREATE TABLE IF NOT EXISTS {db}.clicks_in
     ad_format            LowCardinality(String) DEFAULT '',
 
     uuid UUID,
-    clicks_uuid UUID
+    clicks_uuid UUID,
+
+    INDEX idx_clicks_in_clicks_uuid clicks_uuid TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = MergeTree
 ORDER BY (event_time_clicks, uuid)
 TTL created_at + INTERVAL 1 HOUR DELETE;
+
+ALTER TABLE {db}.impressions_in
+    ADD COLUMN IF NOT EXISTS impressions_uuid UUID AFTER uuid;
+
+ALTER TABLE {db}.clicks_in
+    ADD COLUMN IF NOT EXISTS clicks_uuid UUID AFTER uuid;
+
+ALTER TABLE {db}.impressions_in
+    ADD INDEX IF NOT EXISTS idx_impressions_in_impressions_uuid impressions_uuid TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE {db}.clicks_in
+    ADD INDEX IF NOT EXISTS idx_clicks_in_clicks_uuid clicks_uuid TYPE bloom_filter(0.01) GRANULARITY 1;
 
 
 -- ============================================================
@@ -297,6 +313,12 @@ PARTITION BY toYYYYMMDD(event_date)
 ORDER BY event_time
 TTL event_date + INTERVAL 6 MONTH DELETE
 SETTINGS index_granularity = 8192;
+
+ALTER TABLE {db}.fact_impressions
+    ADD COLUMN IF NOT EXISTS impressions_uuid UUID AFTER uuid;
+
+ALTER TABLE {db}.fact_clicks
+    ADD COLUMN IF NOT EXISTS clicks_uuid UUID AFTER uuid;
 
 
 -- ============================================================


### PR DESCRIPTION
### Motivation

- Provide stable linkage identifiers for impressions and clicks and improve lookup performance on streaming input tables.
- Make schema changes safe for migrations by adding `IF NOT EXISTS` `ALTER TABLE` statements for columns and indexes.

### Description

- Add `impressions_uuid` and `clicks_uuid` UUID columns to the `{db}.impressions_in` and `{db}.clicks_in` input tables respectively and include a `bloom_filter` index for each (`idx_impressions_in_impressions_uuid`, `idx_clicks_in_clicks_uuid`).
- Add `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` and `ALTER TABLE ... ADD INDEX IF NOT EXISTS` statements to ensure idempotent schema migrations for the new UUID columns and indexes.
- Add `impressions_uuid` and `clicks_uuid` columns to the `{db}.fact_impressions` and `{db}.fact_clicks` fact tables with `ADD COLUMN IF NOT EXISTS` to preserve compatibility with existing data.

### Testing

- Ran the repository tests with `go test ./...` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e03000f483288a125afb7749c12d)